### PR TITLE
Fix timeout select duration button

### DIFF
--- a/src/support/compiled.css
+++ b/src/support/compiled.css
@@ -624,7 +624,7 @@ base0F  #deaf8f  Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php 
 #app-mount .root-g14mjS .item-2OyinQ {
     border-color: var(--background-primary);
 }
-#app-mount .root-g14mjS .item-2OyinQ:not(.selectorButtonSelected-3Z0WNU) {
+#app-mount .root-g14mjS .item-2OyinQ:not(.selectorButtonSelected-1VZ6hz) {
     background-color: var(--background-tertiary);
 }
 #app-mount .root-g14mjS .message-G6O-Wv {

--- a/src/theme/modals/_modals.scss
+++ b/src/theme/modals/_modals.scss
@@ -39,7 +39,7 @@
     .item-2OyinQ {
         border-color: var(--background-primary);
     }
-    .item-2OyinQ:not(.selectorButtonSelected-3Z0WNU) {
+    .item-2OyinQ:not(.selectorButtonSelected-1VZ6hz) {
         background-color: var(--background-tertiary);
     }
     // delete message


### PR DESCRIPTION
This PR fixes the button selected in the timeout modal being dark and not the button selection color. You could not understand what duration you had selected.

**Before:**
![before](https://user-images.githubusercontent.com/38290480/150496891-4f318a54-d226-4bf0-9759-f08ceb616b91.png)

**After:**
![after](https://user-images.githubusercontent.com/38290480/150496938-34153055-ecc0-4282-826e-1761e24927ea.png)

