### PR TITLE
fix: Nitro page and theme-amoled class

### DIFF
--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -210,11 +210,11 @@ html.theme-dark .theme-light .root_a28985,
   --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container__4bde3 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) :is(.scroller__1f96e,
+:is(.theme-dark, .theme-midnight) :is(.scroller__1f96e,
 .auto_a48086,
 .thin_b1c063,
 .peopleColumn__51df3,
@@ -223,218 +223,218 @@ html.theme-dark .theme-light .root_a28985,
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .bar_e58961 {
+:is(.theme-dark, .theme-midnight) #app-mount .bar_e58961 {
   background-color: var(--background-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .markDash_dc3ae9 {
+:is(.theme-dark, .theme-midnight) #app-mount .markDash_dc3ae9 {
   background: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72.themed_b152d4 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
   background: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 .children__32014::after {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
   background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
   background-color: var(--primary-730);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_c727b6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_c727b6 {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
   background-color: var(--background-modifier-selected);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
   background: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
   background-color: var(--background-modifier-selected);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .messageListItem__6a4fb:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .messageListItem__6a4fb:hover {
   background-color: rgba(255, 255, 255, 0.015);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b {
+:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
+:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__10dc7,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__7590f,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .header__60bef,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .emptyPage__3e15d {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__10dc7,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__7590f,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .header__60bef,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .emptyPage__3e15d {
   background-color: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .profileCard_bd55ee {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .profileCard_bd55ee {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
   background-color: var(--background-modifier-hover);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .iconBackground__61963 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .iconBackground__61963 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__515b3:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__515b3:hover {
   background-color: var(--background-modifier-hover);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73 {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73 {
   background-color: var(--button-secondary-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
   background-color: var(--button-secondary-background-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:active {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:active {
   background-color: var(--button-secondary-background-active);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .key__06fe6 {
+:is(.theme-dark, .theme-midnight) #app-mount .key__06fe6 {
   box-shadow: inset 0 -4px 0 var(--primary-760);
   background-color: var(--primary-660);
 }
 
-:is(.theme-dark, .theme-amoled) .folder__17546.hover__043de {
+:is(.theme-dark, .theme-midnight) .folder__17546.hover__043de {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
-:is(.theme-dark, .theme-amoled) #app-mount [class=circleIconButton_d8df29] {
+:is(.theme-dark, .theme-midnight) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
+:is(.theme-dark, .theme-midnight) #app-mount [class=circleIconButton_d8df29] {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) .container_b2ce9c {
+:is(.theme-dark, .theme-midnight) .container_b2ce9c {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .member_aa4760,
-:is(.theme-dark, .theme-amoled) #app-mount .members__9f47b {
+:is(.theme-dark, .theme-midnight) #app-mount .member_aa4760,
+:is(.theme-dark, .theme-midnight) #app-mount .members__9f47b {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .contentWrapper__85d37 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .contentWrapper__85d37 {
   background: var(--modal-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .authBox__7196a {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .authBox__7196a {
   background-color: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .navRow_bb8efc {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .navRow_bb8efc {
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) .theme-light .root_a28985 {
+:is(.theme-dark, .theme-midnight) .theme-light .root_a28985 {
   color: var(--primary-300);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .message__04d9f {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .message__04d9f {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.rootWithShadow__073a7 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.rootWithShadow__073a7 {
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footerSeparator__57d95 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footerSeparator__57d95 {
   box-shadow: inset 0 1px 0 var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .container__7712a {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footer__13977 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footer__13977 {
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
   background-color: var(--modal-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
+:is(.theme-dark, .theme-midnight) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
   background-color: var(--background-secondary);
   border-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 {
   background-color: var(--modal-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
   box-shadow: inset 0 1px 0 hsl(var(--primary-900-hsl)/0.6);
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .cardPrimary_cb7a0e {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .cardPrimary_cb7a0e {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .default__3e2f5 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .default__3e2f5 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
+:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .overlay_ef4f80 {
+:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .overlay_ef4f80 {
   background: none !important;
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .previewDark__016ac {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .previewDark__016ac {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
+:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
+:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .directoryContainer_d3edd9 {
+:is(.theme-dark, .theme-midnight) #app-mount .directoryContainer_d3edd9 {
   background-color: var(--background-primary);
 }
 
@@ -569,292 +569,292 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .pageWrapper_fef757 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .pageWrapper_fef757 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input {
   color: var(--primary-260);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
   color: var(--primary-400);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
   color: var(--interactive-normal);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c {
+:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
+:is(.theme-dark, .theme-midnight) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .action_c957d9 {
+:is(.theme-dark, .theme-midnight) #app-mount .action_c957d9 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebarCardWrapper__2c840 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebarCardWrapper__2c840 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .headerIcon__8b099 {
+:is(.theme-dark, .theme-midnight) #app-mount .headerIcon__8b099 {
   background-color: var(--background-tertiary);
   border-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .shop_b31ed2 {
+:is(.theme-dark, .theme-midnight) #app-mount .shop_b31ed2 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .addGamePopout_e4ca8f {
+:is(.theme-dark, .theme-midnight) #app-mount .addGamePopout_e4ca8f {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .autocompleteArrow__353a5 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .autocompleteArrow__353a5 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .sectionTag_b0df68 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .sectionTag_b0df68 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d {
+:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
+:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 {
+:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 {
   background-color: var(--background-floating);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
+:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .phoneFieldPopout__3e064 {
+:is(.theme-dark, .theme-midnight) #app-mount .phoneFieldPopout__3e064 {
   background-color: var(--background-floating);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
+:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
+:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
   border-radius: 35%;
   background-color: var(--background-secondary-alt);
   background-image: none;
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_d27846 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_d27846 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .customColorPicker__3cb6a {
+:is(.theme-dark, .theme-midnight) #app-mount .customColorPicker__3cb6a {
   border: none;
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 {
+:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 {
   background-color: var(--background-floating);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
-  background-color: var(--background-floating);
-}
-
-:is(.theme-dark, .theme-amoled) #app-mount .quickSelectPopout_c0cf80 {
+:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
   background-color: var(--background-floating);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c {
+:is(.theme-dark, .theme-midnight) #app-mount .quickSelectPopout_c0cf80 {
+  background-color: var(--background-floating);
+}
+
+:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
+:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .focused_f9cf2c {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .focused_f9cf2c {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .soundButton__5ad7b {
+:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .soundButton__5ad7b {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .keybindHint__70c7e {
+:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .keybindHint__70c7e {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .body__4e929 {
+:is(.theme-dark, .theme-midnight) #app-mount .body__4e929 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .default__3e2f5 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .default__3e2f5 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierHeaderContent__27033 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierHeaderContent__27033 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .prefixInput__38dcc {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .prefixInput__38dcc {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .backgroundContainer__06189 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .backgroundContainer__06189 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .containerFooter_c8da8a {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .containerFooter_c8da8a {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 {
   background: var(--button-secondary-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
   background: var(--button-secondary-background-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
   background: var(--button-secondary-background-disabled);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 {
   border-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
   background-color: var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierBody__615a1 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierBody__615a1 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegion__60457,
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegion__60457,
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .integration_d2f026 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .integration_d2f026 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .guildHeader__30707 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .guildHeader__30707 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
   border-bottom-color: var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
   border-color: var(--background-tertiary);
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .preview_f42b5d {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .preview_f42b5d {
   border-color: var(--background-secondary);
   background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
   color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .container__0c807 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .container__0c807 {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b {
   box-shadow: none;
   border-bottom: 1px solid var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
   border-color: var(--background-tertiary);
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
   background-color: var(--background-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
   color: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 nav {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 nav {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller] {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller] {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
   background-color: transparent;
 }
 
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
   background-color: transparent;
 }
 
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
   background-color: var(--background-primary);
 }

--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -90,7 +90,7 @@ html.theme-dark .theme-light .root_a28985,
   --background-modifier-hover: hsl(var(--primary-760-hsl)/0.4) !important;
   --background-modifier-selected: hsl(var(--primary-760-hsl)/0.6) !important;
   --background-nested-floating: var(--primary-830) !important;
-  --background-primary: #000000 !important;
+  --background-primary: var(--black-500) !important;
   --background-secondary: var(--primary-830) !important;
   --background-secondary-alt: var(--primary-800) !important;
   --background-tertiary: var(--primary-860) !important;
@@ -136,7 +136,7 @@ html.theme-dark .theme-light .root_a28985,
   --deprecated-card-editable-bg: hsl(var(--primary-700-hsl)/0.3) !important;
   --deprecated-quickswitcher-input-background: var(--primary-400) !important;
   --deprecated-quickswitcher-input-placeholder: hsl(var(--white-500-hsl)/0.3) !important;
-  --deprecated-store-bg: var(--primary-600) !important;
+  --deprecated-store-bg: var(--black-500) !important;
   --deprecated-text-input-bg: var(--primary-700) !important;
   --deprecated-text-input-border: hsl(var(--black-500-hsl)/0.3) !important;
   --deprecated-text-input-border-disabled: var(--primary-700) !important;
@@ -147,7 +147,7 @@ html.theme-dark .theme-light .root_a28985,
   --forum-post-tag-background: hsl(var(--primary-660-hsl)/0.9) !important;
   --header-primary: var(--primary-130) !important;
   --header-secondary: var(--primary-345) !important;
-  --home-background: var(--primary-760) !important;
+  --home-background: var(--black-500) !important;
   --home-card-resting-border: hsl(var(--transparent-hsl)/0) !important;
   --info-danger-text: var(--white-500) !important;
   --info-help-text: var(--white-500) !important;
@@ -204,10 +204,9 @@ html.theme-dark .theme-light .root_a28985,
   --profile-role-pill-border-color: var(--interactive-normal);
   --search-popout-option-fade: linear-gradient(90deg,hsl(var(--primary-830-hsl)/0),hsl(var(--primary-830-hsl)/1) 80%) !important;
   --search-popout-option-fade-hover: linear-gradient(90deg,hsl(var(--primary-800-hsl)/0),var(--primary-800) 50%) !important;
-  --home-background: var(--primary-900) !important;
-  --dark-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
-  --dark-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
-  --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
+  --legacy-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
+  --legacy-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
+  --legacy-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 }
 
 :is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
@@ -230,12 +229,6 @@ html.theme-dark .theme-light .root_a28985,
   background: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
-  background: var(--background-primary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
-  background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
-}
 :is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
@@ -255,31 +248,28 @@ html.theme-dark .theme-light .root_a28985,
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
-  background-color: var(--background-primary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_a4e239 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .card__2c1e2 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
   background-color: var(--background-modifier-selected);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
   background: transparent;
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__036bf {
   background-color: var(--background-modifier-selected);
 }
 
@@ -585,10 +575,10 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   color: var(--interactive-normal);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .mainTableContainer__5ffe0 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .container__7712a {
   background-color: var(--background-secondary);
 }
 

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -89,7 +89,7 @@
 	  --background-modifier-hover: hsl(var(--primary-760-hsl)/0.4) !important;
 	  --background-modifier-selected: hsl(var(--primary-760-hsl)/0.6) !important;
 	  --background-nested-floating: var(--primary-830) !important;
-	  --background-primary: #000000 !important;
+	  --background-primary: var(--black-500) !important;
 	  --background-secondary: var(--primary-830) !important;
 	  --background-secondary-alt: var(--primary-800) !important;
 	  --background-tertiary: var(--primary-860) !important;
@@ -135,7 +135,7 @@
 	  --deprecated-card-editable-bg: hsl(var(--primary-700-hsl)/0.3) !important;
 	  --deprecated-quickswitcher-input-background: var(--primary-400) !important;
 	  --deprecated-quickswitcher-input-placeholder: hsl(var(--white-500-hsl)/0.3) !important;
-	  --deprecated-store-bg: var(--primary-600) !important;
+	  --deprecated-store-bg: var(--black-500) !important;
 	  --deprecated-text-input-bg: var(--primary-700) !important;
 	  --deprecated-text-input-border: hsl(var(--black-500-hsl)/0.3) !important;
 	  --deprecated-text-input-border-disabled: var(--primary-700) !important;
@@ -146,7 +146,7 @@
 	  --forum-post-tag-background: hsl(var(--primary-660-hsl)/0.9) !important;
 	  --header-primary: var(--primary-130) !important;
 	  --header-secondary: var(--primary-345) !important;
-	  --home-background: var(--primary-760) !important;
+	  --home-background: var(--black-500) !important;
 	  --home-card-resting-border: hsl(var(--transparent-hsl)/0) !important;
 	  --info-danger-text: var(--white-500) !important;
 	  --info-help-text: var(--white-500) !important;
@@ -203,10 +203,9 @@
 	  --profile-role-pill-border-color: var(--interactive-normal);
 	  --search-popout-option-fade: linear-gradient(90deg,hsl(var(--primary-830-hsl)/0),hsl(var(--primary-830-hsl)/1) 80%) !important;
 	  --search-popout-option-fade-hover: linear-gradient(90deg,hsl(var(--primary-800-hsl)/0),var(--primary-800) 50%) !important;
-	  --home-background: var(--primary-900) !important;
-	  --dark-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
-	  --dark-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
-	  --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
+	  --legacy-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
+	  --legacy-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
+	  --legacy-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 	}
 	
 	:is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
@@ -229,12 +228,6 @@
 	  background: var(--background-accent);
 	}
 	
-	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
-	  background: var(--background-primary);
-	}
-	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
-	  background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
-	}
 	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
 	  background-color: var(--background-secondary);
 	}
@@ -254,31 +247,28 @@
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
-	  background-color: var(--background-primary);
-	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_a4e239 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .card__2c1e2 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:hover {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:active {
 	  background-color: var(--background-modifier-active);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
 	  background-color: var(--background-modifier-selected);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
 	  background: transparent;
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf:active {
 	  background-color: var(--background-modifier-active);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__036bf {
 	  background-color: var(--background-modifier-selected);
 	}
 	
@@ -584,10 +574,10 @@
 	  color: var(--interactive-normal);
 	}
 	
-	:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+	:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .mainTableContainer__5ffe0 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
+	:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .container__7712a {
 	  background-color: var(--background-secondary);
 	}
 	

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -209,11 +209,11 @@
 	  --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .container__4bde3 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) :is(.scroller__1f96e,
+	:is(.theme-dark, .theme-midnight) :is(.scroller__1f96e,
 	.auto_a48086,
 	.thin_b1c063,
 	.peopleColumn__51df3,
@@ -222,218 +222,218 @@
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .bar_e58961 {
+	:is(.theme-dark, .theme-midnight) #app-mount .bar_e58961 {
 	  background-color: var(--background-accent);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .markDash_dc3ae9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .markDash_dc3ae9 {
 	  background: var(--background-accent);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .container__11d72.themed_b152d4 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
 	  background: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 .children__32014::after {
+	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
 	  background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] {
+	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
-	:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
+	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
+	:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
 	  background-color: var(--primary-730);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_c727b6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_c727b6 {
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
 	  background-color: var(--background-modifier-active);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
 	  background-color: var(--background-modifier-selected);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
 	  background: transparent;
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
 	  background-color: var(--background-modifier-active);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
 	  background-color: var(--background-modifier-selected);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .messageListItem__6a4fb:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .messageListItem__6a4fb:hover {
 	  background-color: rgba(255, 255, 255, 0.015);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b {
+	:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
+	:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__10dc7,
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__7590f,
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .header__60bef,
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .emptyPage__3e15d {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__10dc7,
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__7590f,
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .header__60bef,
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .emptyPage__3e15d {
 	  background-color: transparent;
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
 	  background-color: var(--background-modifier-active);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .profileCard_bd55ee {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .profileCard_bd55ee {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
 	  background-color: var(--background-modifier-hover);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .iconBackground__61963 {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .iconBackground__61963 {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__515b3:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__515b3:hover {
 	  background-color: var(--background-modifier-hover);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73 {
+	:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73 {
 	  background-color: var(--button-secondary-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
 	  background-color: var(--button-secondary-background-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:active {
+	:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:active {
 	  background-color: var(--button-secondary-background-active);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .key__06fe6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .key__06fe6 {
 	  box-shadow: inset 0 -4px 0 var(--primary-760);
 	  background-color: var(--primary-660);
 	}
 	
-	:is(.theme-dark, .theme-amoled) .folder__17546.hover__043de {
+	:is(.theme-dark, .theme-midnight) .folder__17546.hover__043de {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
-	:is(.theme-dark, .theme-amoled) #app-mount [class=circleIconButton_d8df29] {
+	:is(.theme-dark, .theme-midnight) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
+	:is(.theme-dark, .theme-midnight) #app-mount [class=circleIconButton_d8df29] {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) .container_b2ce9c {
+	:is(.theme-dark, .theme-midnight) .container_b2ce9c {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .member_aa4760,
-	:is(.theme-dark, .theme-amoled) #app-mount .members__9f47b {
+	:is(.theme-dark, .theme-midnight) #app-mount .member_aa4760,
+	:is(.theme-dark, .theme-midnight) #app-mount .members__9f47b {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .contentWrapper__85d37 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .contentWrapper__85d37 {
 	  background: var(--modal-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .authBox__7196a {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .authBox__7196a {
 	  background-color: transparent;
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .navRow_bb8efc {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .navRow_bb8efc {
 	  background-color: var(--modal-footer-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) .theme-light .root_a28985 {
+	:is(.theme-dark, .theme-midnight) .theme-light .root_a28985 {
 	  color: var(--primary-300);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .message__04d9f {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .message__04d9f {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.rootWithShadow__073a7 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.rootWithShadow__073a7 {
 	  box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footerSeparator__57d95 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footerSeparator__57d95 {
 	  box-shadow: inset 0 1px 0 var(--modal-footer-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .container__7712a {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .container__7712a {
 	  background-color: var(--input-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footer__13977 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footer__13977 {
 	  background-color: var(--modal-footer-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
 	  background-color: var(--modal-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
+	:is(.theme-dark, .theme-midnight) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
 	  background-color: var(--background-secondary);
 	  border-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 {
 	  background-color: var(--modal-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
 	  box-shadow: inset 0 1px 0 hsl(var(--primary-900-hsl)/0.6);
 	  background-color: var(--modal-footer-background);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .cardPrimary_cb7a0e {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .cardPrimary_cb7a0e {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .default__3e2f5 {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .default__3e2f5 {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
+	:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .overlay_ef4f80 {
+	:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .overlay_ef4f80 {
 	  background: none !important;
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .previewDark__016ac {
+	:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .previewDark__016ac {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
+	:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
+	:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .directoryContainer_d3edd9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .directoryContainer_d3edd9 {
 	  background-color: var(--background-primary);
 	}
 	
@@ -568,293 +568,293 @@
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .pageWrapper_fef757 {
+	:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .pageWrapper_fef757 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 {
+	:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 {
 	  background-color: var(--input-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input {
+	:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input {
 	  color: var(--primary-260);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
+	:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
 	  color: var(--primary-400);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
+	:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
 	  color: var(--interactive-normal);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .container__7712a {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
 	  background-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c {
+	:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c:hover {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .action_c957d9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .action_c957d9 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebarCardWrapper__2c840 {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebarCardWrapper__2c840 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .headerIcon__8b099 {
+	:is(.theme-dark, .theme-midnight) #app-mount .headerIcon__8b099 {
 	  background-color: var(--background-tertiary);
 	  border-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .shop_b31ed2 {
+	:is(.theme-dark, .theme-midnight) #app-mount .shop_b31ed2 {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .addGamePopout_e4ca8f {
+	:is(.theme-dark, .theme-midnight) #app-mount .addGamePopout_e4ca8f {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .autocompleteArrow__353a5 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .autocompleteArrow__353a5 {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .sectionTag_b0df68 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .sectionTag_b0df68 {
 	  background-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d {
+	:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d {
 	  background-color: var(--background-tertiary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
+	:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 {
+	:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 {
 	  background-color: var(--background-floating);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
+	:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .phoneFieldPopout__3e064 {
+	:is(.theme-dark, .theme-midnight) #app-mount .phoneFieldPopout__3e064 {
 	  background-color: var(--background-floating);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
+	:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
+	:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
 	  border-radius: 35%;
 	  background-color: var(--background-secondary-alt);
 	  background-image: none;
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .container_d27846 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_d27846 {
 	  background-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .customColorPicker__3cb6a {
+	:is(.theme-dark, .theme-midnight) #app-mount .customColorPicker__3cb6a {
 	  border: none;
 	  box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 {
 	  background-color: var(--background-floating);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
-	  background-color: var(--background-floating);
-	}
-	
-	:is(.theme-dark, .theme-amoled) #app-mount .quickSelectPopout_c0cf80 {
+	:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
 	  background-color: var(--background-floating);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c {
+	:is(.theme-dark, .theme-midnight) #app-mount .quickSelectPopout_c0cf80 {
+	  background-color: var(--background-floating);
+	}
+	
+	:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
+	:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .focused_f9cf2c {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .focused_f9cf2c {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
-	:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
+	:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
 	  background-color: var(--background-tertiary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .soundButton__5ad7b {
+	:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .soundButton__5ad7b {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .keybindHint__70c7e {
+	:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .keybindHint__70c7e {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .body__4e929 {
+	:is(.theme-dark, .theme-midnight) #app-mount .body__4e929 {
 	  background-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .default__3e2f5 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .default__3e2f5 {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierHeaderContent__27033 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierHeaderContent__27033 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .prefixInput__38dcc {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .prefixInput__38dcc {
 	  background-color: var(--input-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .backgroundContainer__06189 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .backgroundContainer__06189 {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .containerFooter_c8da8a {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .containerFooter_c8da8a {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 {
 	  background: var(--button-secondary-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
 	  background: var(--button-secondary-background-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
 	  background: var(--button-secondary-background-disabled);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 {
 	  border-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
 	  background-color: var(--background-modifier-accent);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierBody__615a1 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierBody__615a1 {
 	  background-color: var(--background-secondary-alt);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegion__60457,
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegion__60457,
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .integration_d2f026 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .integration_d2f026 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .guildHeader__30707 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .guildHeader__30707 {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
 	  background-color: var(--background-modifier-hover);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
 	  border-bottom-color: var(--background-modifier-accent);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
 	  border-color: var(--background-tertiary);
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .preview_f42b5d {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .preview_f42b5d {
 	  border-color: var(--background-secondary);
 	  background-color: var(--background-primary) !important;
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
 	  color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .container__0c807 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .container__0c807 {
 	  background-color: var(--input-background);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b {
 	  box-shadow: none;
 	  border-bottom: 1px solid var(--background-modifier-accent);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
 	  border-color: var(--background-tertiary);
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
 	  background-color: var(--background-accent);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
 	  color: var(--background-accent);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 nav {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 nav {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller] {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller] {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
 	  background-color: transparent;
 	}
 	
-	:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a {
+	:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
+	:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
 	  background-color: var(--background-secondary);
 	}
 	
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
 	  background-color: transparent;
 	}
 	
-	:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
+	:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
 	  background-color: var(--background-primary);
 	}
 }

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -197,11 +197,11 @@ html.theme-dark .theme-light .root_a28985,
   --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container__4bde3 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) :is(.scroller__1f96e,
+:is(.theme-dark, .theme-midnight) :is(.scroller__1f96e,
 .auto_a48086,
 .thin_b1c063,
 .peopleColumn__51df3,
@@ -210,218 +210,218 @@ html.theme-dark .theme-light .root_a28985,
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .bar_e58961 {
+:is(.theme-dark, .theme-midnight) #app-mount .bar_e58961 {
   background-color: var(--background-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .markDash_dc3ae9 {
+:is(.theme-dark, .theme-midnight) #app-mount .markDash_dc3ae9 {
   background: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72.themed_b152d4 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
   background: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 .children__32014::after {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
   background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchAnswer_b452e7,
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] .searchFilter__118cb {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .optionPill_f86b98, .container_def45c .form__13a2c .optionPill_f86b98 {
   background-color: var(--primary-730);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb, .container_def45c .form__13a2c .channelAttachmentArea__740bf .upload_c98ecb {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_c727b6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_c727b6 {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
   background-color: var(--background-modifier-selected);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
   background: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
   background-color: var(--background-modifier-selected);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .messageListItem__6a4fb:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .messageListItem__6a4fb:hover {
   background-color: rgba(255, 255, 255, 0.015);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b {
+:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
+:is(.theme-dark, .theme-midnight) #app-mount .tile_ebc93b .invalidPoop__03aa3 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__10dc7,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__7590f,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .header__60bef,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .emptyPage__3e15d {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__10dc7,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__7590f,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .header__60bef,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .scrollerContainer_bf5dbd,
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .emptyPage__3e15d {
   background-color: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .prompt__1b100 .selected__90dd8 {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .profileCard_bd55ee {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .profileCard_bd55ee {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .channelRow__96673:not(.disabled__583e7):hover {
   background-color: var(--background-modifier-hover);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .wrapper_bd2abe.minimum_ebf000 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .iconBackground__61963 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .iconBackground__61963 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 .container__515b3:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container__515b3:hover {
   background-color: var(--background-modifier-hover);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73 {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73 {
   background-color: var(--button-secondary-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:hover, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:hover {
   background-color: var(--button-secondary-background-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-amoled) #app-mount .button__66e8c .buttonColor_a6eb73:active {
+:is(.theme-dark, .theme-midnight) #app-mount .button__66e8c.buttonColor_a6eb73:active, :is(.theme-dark, .theme-midnight) #app-mount .button__66e8c .buttonColor_a6eb73:active {
   background-color: var(--button-secondary-background-active);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .key__06fe6 {
+:is(.theme-dark, .theme-midnight) #app-mount .key__06fe6 {
   box-shadow: inset 0 -4px 0 var(--primary-760);
   background-color: var(--primary-660);
 }
 
-:is(.theme-dark, .theme-amoled) .folder__17546.hover__043de {
+:is(.theme-dark, .theme-midnight) .folder__17546.hover__043de {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
-:is(.theme-dark, .theme-amoled) #app-mount [class=circleIconButton_d8df29] {
+:is(.theme-dark, .theme-midnight) #app-mount [class=wrapper_d281dd] .childWrapper__01b9c,
+:is(.theme-dark, .theme-midnight) #app-mount [class=circleIconButton_d8df29] {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) .container_b2ce9c {
+:is(.theme-dark, .theme-midnight) .container_b2ce9c {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .member_aa4760,
-:is(.theme-dark, .theme-amoled) #app-mount .members__9f47b {
+:is(.theme-dark, .theme-midnight) #app-mount .member_aa4760,
+:is(.theme-dark, .theme-midnight) #app-mount .members__9f47b {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .contentWrapper__85d37 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .contentWrapper__85d37 {
   background: var(--modal-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .authBox__7196a {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .authBox__7196a {
   background-color: transparent;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .navRow_bb8efc {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .navRow_bb8efc {
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) .theme-light .root_a28985 {
+:is(.theme-dark, .theme-midnight) .theme-light .root_a28985 {
   color: var(--primary-300);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .message__04d9f {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .message__04d9f {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.rootWithShadow__073a7 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.rootWithShadow__073a7 {
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footerSeparator__57d95 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footerSeparator__57d95 {
   box-shadow: inset 0 1px 0 var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .container__7712a {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .footer__13977 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .footer__13977 {
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .keyboardShortcutsModal__74c71 {
   background-color: var(--modal-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
+:is(.theme-dark, .theme-midnight) #app-mount .modal_c01034 .verifiedRoleHasRole__86f1d {
   background-color: var(--background-secondary);
   border-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 {
   background-color: var(--modal-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985.uploadModal_eae2a0 .footer_ceda43 {
   box-shadow: inset 0 1px 0 hsl(var(--primary-900-hsl)/0.6);
   background-color: var(--modal-footer-background);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .cardPrimary_cb7a0e {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .cardPrimary_cb7a0e {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .default__3e2f5 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .default__3e2f5 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
+:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .optionButtonWrapper__4072c.selected__90dd8 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 .overlay_ef4f80 {
+:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 .overlay_ef4f80 {
   background: none !important;
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 .previewDark__016ac {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 .previewDark__016ac {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
+:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .separator_c2ecc6 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
+:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f .applicationStreamingPreviewWrapper__97a95 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .directoryContainer_d3edd9 {
+:is(.theme-dark, .theme-midnight) #app-mount .directoryContainer_d3edd9 {
   background-color: var(--background-primary);
 }
 
@@ -556,292 +556,292 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .pageWrapper_fef757 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .pageWrapper_fef757 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input {
   color: var(--primary-260);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 input::placeholder {
   color: var(--primary-400);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .searchIcon_f30c40, :is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 .searchBox_a63854 .closeIcon__3dfb5 {
   color: var(--interactive-normal);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c {
+:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .row__70f4c:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .row__70f4c:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
+:is(.theme-dark, .theme-midnight) #app-mount .clickableAction_bef9b9:hover .action_c957d9 {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .action_c957d9 {
+:is(.theme-dark, .theme-midnight) #app-mount .action_c957d9 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebarCardWrapper__2c840 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebarCardWrapper__2c840 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .headerIcon__8b099 {
+:is(.theme-dark, .theme-midnight) #app-mount .headerIcon__8b099 {
   background-color: var(--background-tertiary);
   border-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .shop_b31ed2 {
+:is(.theme-dark, .theme-midnight) #app-mount .shop_b31ed2 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .addGamePopout_e4ca8f {
+:is(.theme-dark, .theme-midnight) #app-mount .addGamePopout_e4ca8f {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .autocompleteArrow__353a5 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .header__02652, :is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .autocompleteArrow__353a5 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda .sectionTag_b0df68 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda .sectionTag_b0df68 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d {
+:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
+:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d .categoryHeader_f97a5f {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 {
+:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 {
   background-color: var(--background-floating);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
+:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 .footer__36118 {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .phoneFieldPopout__3e064 {
+:is(.theme-dark, .theme-midnight) #app-mount .phoneFieldPopout__3e064 {
   background-color: var(--background-floating);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
+:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .emptyHintCard_f3e81a {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
+:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 .imageLoading__37d01 {
   border-radius: 35%;
   background-color: var(--background-secondary-alt);
   background-image: none;
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .container_d27846 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_d27846 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .customColorPicker__3cb6a {
+:is(.theme-dark, .theme-midnight) #app-mount .customColorPicker__3cb6a {
   border: none;
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 {
+:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 {
   background-color: var(--background-floating);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
-  background-color: var(--background-floating);
-}
-
-:is(.theme-dark, .theme-amoled) #app-mount .quickSelectPopout_c0cf80 {
+:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 .overflowRolesPopoutArrow_f3db31 {
   background-color: var(--background-floating);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c {
+:is(.theme-dark, .theme-midnight) #app-mount .quickSelectPopout_c0cf80 {
+  background-color: var(--background-floating);
+}
+
+:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
+:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c .previewContainer_bb1924 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .focused_f9cf2c {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .focused_f9cf2c {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__header {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation,
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__navigation {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__current-month {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--outside-month,
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd .calendarPicker__5c474 .react-datepicker__day--disabled {
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .soundButton__5ad7b {
+:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .soundButton__5ad7b {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 .keybindHint__70c7e {
+:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 .keybindHint__70c7e {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .body__4e929 {
+:is(.theme-dark, .theme-midnight) #app-mount .body__4e929 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .default__3e2f5 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .default__3e2f5 {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .avatarUploaderInnerSquareDisabled__3cfd1 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierHeaderContent__27033 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierHeaderContent__27033 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .prefixInput__38dcc {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .prefixInput__38dcc {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .backgroundContainer__06189 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .backgroundContainer__06189 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .containerFooter_c8da8a {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .containerFooter_c8da8a {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 {
   background: var(--button-secondary-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover {
   background: var(--button-secondary-background-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .iconWrapper__9caa9 .icon_ae3492:hover.disabled_d58a9f {
   background: var(--button-secondary-background-disabled);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 {
   border-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .header_e08fd2 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .headerExpanded__03c29 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .divider__1505d {
   background-color: var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .auditLog__6c805 .changeDetails_ecd760 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .tierBody__615a1 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .tierBody__615a1 {
   background-color: var(--background-secondary-alt);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegion__60457,
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegion__60457,
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .sidebarRegionScroller__1fa7e {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .cardPrimary_cb7a0e.outline_cb0aed {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .connectContainer__8050b .wrapper__03d5e:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .integration_d2f026 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .integration_d2f026 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .guildHeader__30707 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .guildHeader__30707 {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .expandedInfo__47bad {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702 {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .paginator_e620d3 .payment__7d702.hoverablePayment__3ea24:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .paymentPane__9cf01 .bottomDivider_a59d97 {
   border-bottom-color: var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .codeRedemptionRedirect_bc7f36 {
   border-color: var(--background-tertiary);
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .preview_f42b5d {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .preview_f42b5d {
   border-color: var(--background-secondary);
   background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .notches__065e9.gray__4fb3f {
   color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .container__0c807 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .container__0c807 {
   background-color: var(--input-background);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b {
   box-shadow: none;
   border-bottom: 1px solid var(--background-modifier-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .game__19f4b .gameNameInput_e25dd8:is(:hover, :focus) {
   border-color: var(--background-tertiary);
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .option_a0c054:not(.selected_ea51d6, :hover) {
   background-color: var(--background-accent);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 .disabled_ab18dc:not(.selected_ea51d6, :hover) {
   color: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 nav {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 nav {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller] {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller] {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 [class*=scroller].fade_ba0fa0 {
   background-color: transparent;
 }
 
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .searchBar_e4ea2a .searchBarComponent__22760 {
   background-color: var(--background-secondary);
 }
 
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .container__7c79d:not(.hasBanner_e78601) .header__104ca:hover {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 .hasBanner_e78601 [class*=scroller-] {
   background-color: transparent;
 }
 
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-amoled) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .container_ca50b9, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .panel_bd8c76, :is(.theme-dark, .theme-midnight) .sidebar_ded4b5 .panels__58331 .wrapper__0ed4a > div {
   background-color: var(--background-primary);
 }

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -77,7 +77,7 @@ html.theme-dark .theme-light .root_a28985,
   --background-modifier-hover: hsl(var(--primary-760-hsl)/0.4) !important;
   --background-modifier-selected: hsl(var(--primary-760-hsl)/0.6) !important;
   --background-nested-floating: var(--primary-830) !important;
-  --background-primary: #000000 !important;
+  --background-primary: var(--black-500) !important;
   --background-secondary: var(--primary-830) !important;
   --background-secondary-alt: var(--primary-800) !important;
   --background-tertiary: var(--primary-860) !important;
@@ -123,7 +123,7 @@ html.theme-dark .theme-light .root_a28985,
   --deprecated-card-editable-bg: hsl(var(--primary-700-hsl)/0.3) !important;
   --deprecated-quickswitcher-input-background: var(--primary-400) !important;
   --deprecated-quickswitcher-input-placeholder: hsl(var(--white-500-hsl)/0.3) !important;
-  --deprecated-store-bg: var(--primary-600) !important;
+  --deprecated-store-bg: var(--black-500) !important;
   --deprecated-text-input-bg: var(--primary-700) !important;
   --deprecated-text-input-border: hsl(var(--black-500-hsl)/0.3) !important;
   --deprecated-text-input-border-disabled: var(--primary-700) !important;
@@ -134,7 +134,7 @@ html.theme-dark .theme-light .root_a28985,
   --forum-post-tag-background: hsl(var(--primary-660-hsl)/0.9) !important;
   --header-primary: var(--primary-130) !important;
   --header-secondary: var(--primary-345) !important;
-  --home-background: var(--primary-760) !important;
+  --home-background: var(--black-500) !important;
   --home-card-resting-border: hsl(var(--transparent-hsl)/0) !important;
   --info-danger-text: var(--white-500) !important;
   --info-help-text: var(--white-500) !important;
@@ -191,10 +191,9 @@ html.theme-dark .theme-light .root_a28985,
   --profile-role-pill-border-color: var(--interactive-normal);
   --search-popout-option-fade: linear-gradient(90deg,hsl(var(--primary-830-hsl)/0),hsl(var(--primary-830-hsl)/1) 80%) !important;
   --search-popout-option-fade-hover: linear-gradient(90deg,hsl(var(--primary-800-hsl)/0),var(--primary-800) 50%) !important;
-  --home-background: var(--primary-900) !important;
-  --dark-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
-  --dark-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
-  --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
+  --legacy-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
+  --legacy-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
+  --legacy-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 }
 
 :is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
@@ -217,12 +216,6 @@ html.theme-dark .theme-light .root_a28985,
   background: var(--background-accent);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container__11d72.themed_b152d4 {
-  background: var(--background-primary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 .children__32014::after {
-  background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
-}
 :is(.theme-dark, .theme-midnight) #app-mount .container__11d72 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
@@ -242,31 +235,28 @@ html.theme-dark .theme-light .root_a28985,
   background-color: var(--background-tertiary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 {
-  background-color: var(--background-primary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_a4e239 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .mainCard__8a660, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__4abd7, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .increasedActivityMainCard__916ed, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__1b27a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_a4e239 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .card__2c1e2 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .loadingCard_a6aa0a, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .card__2c1e2 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:hover {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:hover {
   background-color: var(--background-modifier-hover);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd:active {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd.isOpen_d88bb6 {
   background-color: var(--background-modifier-selected);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container_c24cbd .textContentFooter__5a630 {
   background: transparent;
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf:active {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06:active, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf:active {
   background-color: var(--background-modifier-active);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .chat__52833 .container_b181b6 .container__15ddf.isOpen__036bf {
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__99b06.isOpen__036bf, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__8593d, :is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 .container__15ddf.isOpen__036bf {
   background-color: var(--background-modifier-selected);
 }
 
@@ -572,10 +562,10 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   color: var(--interactive-normal);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .mainTableContainer__5ffe0 {
+:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .mainTableContainer__5ffe0 {
   background-color: var(--background-tertiary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 .container__7712a {
+:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e .container__7712a {
   background-color: var(--background-secondary);
 }
 

--- a/src/core/_variables.scss
+++ b/src/core/_variables.scss
@@ -78,7 +78,7 @@ html.theme-dark .theme-light .root_a28985,
     --background-modifier-hover: hsl(var(--primary-760-hsl)/0.4) !important;
     --background-modifier-selected: hsl(var(--primary-760-hsl)/0.6) !important;
     --background-nested-floating: var(--primary-830) !important;
-    --background-primary: #000000 !important;
+    --background-primary: var(--black-500) !important;
     --background-secondary: var(--primary-830) !important;
     --background-secondary-alt: var(--primary-800) !important;
     --background-tertiary: var(--primary-860) !important;
@@ -110,7 +110,7 @@ html.theme-dark .theme-light .root_a28985,
     --button-outline-primary-text: var(--white-500) !important;
     --button-outline-primary-text-active: var(--white-500) !important;
     --button-outline-primary-text-hover: var(--white-500) !important;
-    
+
     --button-secondary-background: var(--primary-700) !important;
     --button-secondary-background-active: var(--primary-600) !important;
     --button-secondary-background-disabled: var(--primary-700) !important;
@@ -126,7 +126,7 @@ html.theme-dark .theme-light .root_a28985,
     --deprecated-card-editable-bg: hsl(var(--primary-700-hsl)/0.3) !important;
     --deprecated-quickswitcher-input-background: var(--primary-400) !important;
     --deprecated-quickswitcher-input-placeholder: hsl(var(--white-500-hsl)/0.3) !important;
-    --deprecated-store-bg: var(--primary-600) !important;
+    --deprecated-store-bg: var(--black-500) !important;
     --deprecated-text-input-bg: var(--primary-700) !important;
     --deprecated-text-input-border: hsl(var(--black-500-hsl)/0.3) !important;
     --deprecated-text-input-border-disabled: var(--primary-700) !important;
@@ -137,7 +137,7 @@ html.theme-dark .theme-light .root_a28985,
     --forum-post-tag-background: hsl(var(--primary-660-hsl)/0.9) !important;
     --header-primary: var(--primary-130) !important;
     --header-secondary: var(--primary-345) !important;
-    --home-background: var(--primary-760) !important;
+    --home-background: var(--black-500) !important;
     --home-card-resting-border: hsl(var(--transparent-hsl)/0) !important;
     --info-danger-text: var(--white-500) !important;
     --info-help-text: var(--white-500) !important;
@@ -177,6 +177,7 @@ html.theme-dark .theme-light .root_a28985,
     --text-normal: var(--primary-300) !important;
     --textbox-markdown-syntax: var(--primary-360) !important;
     --user-profile-header-overflow-background: hsl(var(--primary-700-hsl)/0.5) !important;
+
     --elevation-stroke: 0 0 0 1px hsl(var(--primary-600-hsl)/0.15) !important;
     --elevation-low: 0 1px 0 hsl(var(--primary-630-hsl)/0.2),0 1.5px 0 hsl(var(--primary-600-hsl)/0.05),0 2px 0 hsl(var(--primary-630-hsl)/0.05) !important;
     --elevation-medium: 0 4px 4px hsl(var(--black-500-hsl)/0.16) !important;
@@ -197,9 +198,7 @@ html.theme-dark .theme-light .root_a28985,
     --search-popout-option-fade: linear-gradient(90deg,hsl(var(--primary-830-hsl)/0),hsl(var(--primary-830-hsl)/1) 80%) !important;
     --search-popout-option-fade-hover: linear-gradient(90deg,hsl(var(--primary-800-hsl)/0),var(--primary-800) 50%) !important;
 
-    --home-background: var(--primary-900) !important;
-
-    --dark-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
-    --dark-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
-    --dark-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
+    --legacy-elevation-low: 0 1px 5px 0 hsl(var(--black-500-hsl)/0.3);
+    --legacy-elevation-high: 0 2px 10px 0 hsl(var(--black-500-hsl)/0.2);
+    --legacy-elevation-border: 0 0 0 1px hsl(var(--primary-700-hsl)/0.6);
 }

--- a/src/theme/app/_loading.scss
+++ b/src/theme/app/_loading.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .container__4bde3 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__4bde3 {
     background-color: var(--background-primary);
 }

--- a/src/theme/app/_scrollerbar.scss
+++ b/src/theme/app/_scrollerbar.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled)  :is(
+:is(.theme-dark, .theme-midnight)  :is(
     .scroller__1f96e,
     .auto_a48086,
     .thin_b1c063,

--- a/src/theme/app/_sliders.scss
+++ b/src/theme/app/_sliders.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     .bar_e58961 {
         background-color: var(--background-accent);
     }

--- a/src/theme/app/_toolbar.scss
+++ b/src/theme/app/_toolbar.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .container__11d72 {
+:is(.theme-dark, .theme-midnight) #app-mount .container__11d72 {
     &.themed_b152d4 {
         background: var(--background-primary);
     }

--- a/src/theme/app/_toolbar.scss
+++ b/src/theme/app/_toolbar.scss
@@ -1,10 +1,4 @@
 :is(.theme-dark, .theme-midnight) #app-mount .container__11d72 {
-    &.themed_b152d4 {
-        background: var(--background-primary);
-    }
-    .children__32014::after {
-        background: linear-gradient(90deg, var(--background-primary) 0, var(--background-primary)) !important;
-    }
     [class*="searchBar"] {
         background-color: var(--background-secondary);
         .searchAnswer_b452e7,

--- a/src/theme/chat/_chatbox.scss
+++ b/src/theme/chat/_chatbox.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833, .container_def45c {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833, .container_def45c {
     .form__13a2c {
         .optionPill_f86b98 {
             background-color: var(--primary-730);

--- a/src/theme/chat/_container.scss
+++ b/src/theme/chat/_container.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 {
     .wrapper_c727b6 {
         background-color: var(--background-tertiary);
     }

--- a/src/theme/chat/_forums.scss
+++ b/src/theme/chat/_forums.scss
@@ -1,33 +1,30 @@
-:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 {
-    .container_b181b6 {
-        background-color: var(--background-primary);
-        .mainCard__8a660, .container__4abd7, .increasedActivityMainCard__916ed, .container__1b27a, .container_a4e239 {
-            background-color: var(--background-tertiary);
+:is(.theme-dark, .theme-midnight) #app-mount .container_b181b6 {
+    .mainCard__8a660, .container__4abd7, .increasedActivityMainCard__916ed, .container__1b27a, .container_a4e239 {
+        background-color: var(--background-tertiary);
+    }
+    .loadingCard_a6aa0a, .card__2c1e2 {
+        background-color: var(--background-tertiary);
+    }
+    .container_c24cbd {
+        &:hover {
+            background-color: var(--background-modifier-hover);
         }
-        .loadingCard_a6aa0a, .card__2c1e2 {
-            background-color: var(--background-tertiary);
+        &:active {
+            background-color: var(--background-modifier-active);
         }
-        .container_c24cbd {
-            &:hover {
-                background-color: var(--background-modifier-hover);
-            }
-            &:active {
-                background-color: var(--background-modifier-active);
-            }
-            &.isOpen_d88bb6 {
-                background-color: var(--background-modifier-selected);
-            }
-            .textContentFooter__5a630 {
-                background: transparent;
-            }
+        &.isOpen_d88bb6 {
+            background-color: var(--background-modifier-selected);
         }
-        .container__99b06, .container__15ddf {
-            &:active {
-                background-color: var(--background-modifier-active);
-            }
-            &.isOpen__8593d, &.isOpen__036bf {
-                background-color: var(--background-modifier-selected);
-            }
+        .textContentFooter__5a630 {
+            background: transparent;
+        }
+    }
+    .container__99b06, .container__15ddf {
+        &:active {
+            background-color: var(--background-modifier-active);
+        }
+        &.isOpen__8593d, &.isOpen__036bf {
+            background-color: var(--background-modifier-selected);
         }
     }
 }

--- a/src/theme/chat/_forums.scss
+++ b/src/theme/chat/_forums.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 {
     .container_b181b6 {
         background-color: var(--background-primary);
         .mainCard__8a660, .container__4abd7, .increasedActivityMainCard__916ed, .container__1b27a, .container_a4e239 {

--- a/src/theme/chat/_messages.scss
+++ b/src/theme/chat/_messages.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     // Message Items
     .messageListItem__6a4fb:hover {
         background-color: rgba(255, 255, 255, 0.015);

--- a/src/theme/chat/_onboarding.scss
+++ b/src/theme/chat/_onboarding.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 {
     // Roles
     .container__10dc7,
     .container__7590f,

--- a/src/theme/chat/_voice.scss
+++ b/src/theme/chat/_voice.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .chat__52833 {
+:is(.theme-dark, .theme-midnight) #app-mount .chat__52833 {
     .wrapper_bd2abe.minimum_ebf000 {
         background-color: var(--background-primary);
     }

--- a/src/theme/guilds/_folders.scss
+++ b/src/theme/guilds/_folders.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) .folder__17546.hover__043de {
+:is(.theme-dark, .theme-midnight) .folder__17546.hover__043de {
     background-color: var(--background-secondary-alt);
 }

--- a/src/theme/guilds/_items.scss
+++ b/src/theme/guilds/_items.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     [class="wrapper_d281dd"] .childWrapper__01b9c,
     [class="circleIconButton_d8df29"] {
         background-color: var(--background-secondary-alt);

--- a/src/theme/inputs/_buttons.scss
+++ b/src/theme/inputs/_buttons.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     .button__66e8c.buttonColor_a6eb73, .button__66e8c .buttonColor_a6eb73 {
         background-color: var(--button-secondary-background);
         &:hover {

--- a/src/theme/inputs/_keybinds.scss
+++ b/src/theme/inputs/_keybinds.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .key__06fe6 {
+:is(.theme-dark, .theme-midnight) #app-mount .key__06fe6 {
     box-shadow: inset 0 -4px 0 var(--primary-760);
     background-color: var(--primary-660);
 }

--- a/src/theme/members/_container.scss
+++ b/src/theme/members/_container.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) .container_b2ce9c {
+:is(.theme-dark, .theme-midnight) .container_b2ce9c {
     background-color: var(--background-primary);
 }

--- a/src/theme/members/_member.scss
+++ b/src/theme/members/_member.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     .member_aa4760,
     .members__9f47b {
         background-color: var(--background-primary);

--- a/src/theme/modals/_accept-invite.scss
+++ b/src/theme/modals/_accept-invite.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .contentWrapper__85d37 {
         background: var(--modal-background);
     }

--- a/src/theme/modals/_account-switcher.scss
+++ b/src/theme/modals/_account-switcher.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .authBox__7196a {
         background-color: transparent;
     }

--- a/src/theme/modals/_add-join-server.scss
+++ b/src/theme/modals/_add-join-server.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) .theme-light .root_a28985 {
+:is(.theme-dark, .theme-midnight) .theme-light .root_a28985 {
     color: var(--primary-300);
 }

--- a/src/theme/modals/_delete.scss
+++ b/src/theme/modals/_delete.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .message__04d9f {
         background-color: var(--background-primary);
     }

--- a/src/theme/modals/_generic.scss
+++ b/src/theme/modals/_generic.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     &.rootWithShadow__073a7 {
         box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
     }

--- a/src/theme/modals/_invite.scss
+++ b/src/theme/modals/_invite.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .container__7712a {
         background-color: var(--input-background);
     }

--- a/src/theme/modals/_keybinds.scss
+++ b/src/theme/modals/_keybinds.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .keyboardShortcutsModal__74c71 {
         background-color: var(--modal-background);
     }

--- a/src/theme/modals/_linked-roles.scss
+++ b/src/theme/modals/_linked-roles.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .modal_c01034 {
+:is(.theme-dark, .theme-midnight) #app-mount .modal_c01034 {
     .verifiedRoleHasRole__86f1d {
         background-color: var(--background-secondary);
         border-color: var(--background-secondary);

--- a/src/theme/modals/_modify-attachment.scss
+++ b/src/theme/modals/_modify-attachment.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     &.uploadModal_eae2a0 {
         background-color: var(--modal-background);
         .footer_ceda43 {

--- a/src/theme/modals/_notification-settings.scss
+++ b/src/theme/modals/_notification-settings.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .cardPrimary_cb7a0e {
         background-color: var(--background-secondary);
     }

--- a/src/theme/modals/_onboarding.scss
+++ b/src/theme/modals/_onboarding.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .promptContent__63c03 {
+:is(.theme-dark, .theme-midnight) #app-mount .promptContent__63c03 {
     .optionButtonWrapper__4072c.selected__90dd8 {
         background-color: var(--background-secondary);
     }

--- a/src/theme/modals/_stickers.scss
+++ b/src/theme/modals/_stickers.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .root_a28985 {
+:is(.theme-dark, .theme-midnight) #app-mount .root_a28985 {
     .previewDark__016ac {
         background-color: var(--background-primary);
     }

--- a/src/theme/pages/_active-now.scss
+++ b/src/theme/pages/_active-now.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .nowPlayingColumn_f5023f {
+:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_f5023f {
     .separator_c2ecc6 {
         background-color: var(--background-secondary);
     }

--- a/src/theme/pages/_app-directory.scss
+++ b/src/theme/pages/_app-directory.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .directoryContainer_d3edd9 {
+:is(.theme-dark, .theme-midnight) #app-mount .directoryContainer_d3edd9 {
     background-color: var(--background-primary);
 }

--- a/src/theme/pages/_discovery.scss
+++ b/src/theme/pages/_discovery.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .content__4bf10 {
+:is(.theme-dark, .theme-midnight) #app-mount .content__4bf10 {
     .pageWrapper_fef757 {
         background-color: var(--background-primary);
     }

--- a/src/theme/pages/_members.scss
+++ b/src/theme/pages/_members.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 {
+:is(.theme-dark, .theme-midnight) #app-mount .page__0b66e {
     .mainTableContainer__5ffe0 {
         background-color: var(--background-tertiary);
     }

--- a/src/theme/pages/_members.scss
+++ b/src/theme/pages/_members.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .container_df3aa0 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_df3aa0 {
     .mainTableContainer__5ffe0 {
         background-color: var(--background-tertiary);
     }

--- a/src/theme/pages/_server-guide.scss
+++ b/src/theme/pages/_server-guide.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount {
+:is(.theme-dark, .theme-midnight) #app-mount {
     .row__70f4c {
         background-color: var(--background-tertiary);
         &:hover {

--- a/src/theme/pages/_shop.scss
+++ b/src/theme/pages/_shop.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .shop_b31ed2 {
+:is(.theme-dark, .theme-midnight) #app-mount .shop_b31ed2 {
     background-color: var(--background-primary);
 }

--- a/src/theme/popouts/_add-game.scss
+++ b/src/theme/popouts/_add-game.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .addGamePopout_e4ca8f {
-    background-color: var(--background-primary);   
+:is(.theme-dark, .theme-midnight) #app-mount .addGamePopout_e4ca8f {
+    background-color: var(--background-primary);
 }

--- a/src/theme/popouts/_add-permissions.scss
+++ b/src/theme/popouts/_add-permissions.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .container_e84cda {
+:is(.theme-dark, .theme-midnight) #app-mount .container_e84cda {
     .header__02652, .autocompleteArrow__353a5 {
         background-color: var(--background-tertiary);
     }

--- a/src/theme/popouts/_autocomplete.scss
+++ b/src/theme/popouts/_autocomplete.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .autocomplete_df266d {
+:is(.theme-dark, .theme-midnight) #app-mount .autocomplete_df266d {
     background-color: var(--background-tertiary);
     .categoryHeader_f97a5f {
         background-color: var(--background-tertiary);

--- a/src/theme/popouts/_color-picker.scss
+++ b/src/theme/popouts/_color-picker.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .customColorPicker__3cb6a {
+:is(.theme-dark, .theme-midnight) #app-mount .customColorPicker__3cb6a {
     border: none;
     box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
     background-color: var(--background-tertiary);

--- a/src/theme/popouts/_content-warning.scss
+++ b/src/theme/popouts/_content-warning.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .contentWarningPopout__7d8c2 {
+:is(.theme-dark, .theme-midnight) #app-mount .contentWarningPopout__7d8c2 {
     background-color: var(--background-floating);
     .footer__36118 {
         background-color: var(--background-tertiary);

--- a/src/theme/popouts/_country-code.scss
+++ b/src/theme/popouts/_country-code.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .phoneFieldPopout__3e064 {
+:is(.theme-dark, .theme-midnight) #app-mount .phoneFieldPopout__3e064 {
     background-color: var(--background-floating);
 }

--- a/src/theme/popouts/_drawer.scss
+++ b/src/theme/popouts/_drawer.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .drawerSizingWrapper__30274 {
+:is(.theme-dark, .theme-midnight) #app-mount .drawerSizingWrapper__30274 {
     // Gifs
     .emptyHintCard_f3e81a {
         background-color: var(--background-primary);

--- a/src/theme/popouts/_generic.scss
+++ b/src/theme/popouts/_generic.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .container_d27846 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_d27846 {
     background-color: var(--background-secondary);
 }

--- a/src/theme/popouts/_member-roles.scss
+++ b/src/theme/popouts/_member-roles.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .overflowRolesPopout__88ab9 {
+:is(.theme-dark, .theme-midnight) #app-mount .overflowRolesPopout__88ab9 {
     background-color: var(--background-floating);
     .overflowRolesPopoutArrow_f3db31 {
         background-color: var(--background-floating);

--- a/src/theme/popouts/_region-picker.scss
+++ b/src/theme/popouts/_region-picker.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .quickSelectPopout_c0cf80 {
+:is(.theme-dark, .theme-midnight) #app-mount .quickSelectPopout_c0cf80 {
     background-color: var(--background-floating);
 }

--- a/src/theme/popouts/_screenshare.scss
+++ b/src/theme/popouts/_screenshare.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .streamPreview__1846c {
+:is(.theme-dark, .theme-midnight) #app-mount .streamPreview__1846c {
     background-color: var(--background-secondary);
     .previewContainer_bb1924 {
         background-color: var(--background-secondary-alt);

--- a/src/theme/popouts/_search.scss
+++ b/src/theme/popouts/_search.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .layer_ec16dd {
+:is(.theme-dark, .theme-midnight) #app-mount .layer_ec16dd {
     .focused_f9cf2c {
         background-color: var(--background-secondary);
     }

--- a/src/theme/popouts/_soundboard.scss
+++ b/src/theme/popouts/_soundboard.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .picker__6dca7 {
+:is(.theme-dark, .theme-midnight) #app-mount .picker__6dca7 {
     .soundButton__5ad7b {
         background-color: var(--background-primary);
     }

--- a/src/theme/popouts/_webhook.scss
+++ b/src/theme/popouts/_webhook.scss
@@ -1,3 +1,3 @@
-:is(.theme-dark, .theme-amoled) #app-mount .body__4e929 {
+:is(.theme-dark, .theme-midnight) #app-mount .body__4e929 {
     background-color: var(--background-secondary);
 }

--- a/src/theme/settings/_content.scss
+++ b/src/theme/settings/_content.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 {
     .default__3e2f5 {
         background-color: var(--background-primary);
     }

--- a/src/theme/settings/_guild.scss
+++ b/src/theme/settings/_guild.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 {
     // Overview
     .avatarUploaderInnerSquareDisabled__3cfd1 {
         background-color: var(--background-secondary-alt);

--- a/src/theme/settings/_sidebar.scss
+++ b/src/theme/settings/_sidebar.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 {
     .sidebarRegion__60457,
     .sidebarRegionScroller__1fa7e {
         background-color: var(--background-primary);

--- a/src/theme/settings/_user.scss
+++ b/src/theme/settings/_user.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .layers__1c917 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers__1c917 {
     // Authorized Apps
     .cardPrimary_cb7a0e.outline_cb0aed {
         background-color: var(--background-secondary);

--- a/src/theme/sidebar/_container.scss
+++ b/src/theme/sidebar/_container.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 {
     nav {
         background-color: var(--background-primary);
     }

--- a/src/theme/sidebar/_dm-list.scss
+++ b/src/theme/sidebar/_dm-list.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 {
     .searchBar_e4ea2a {
         background-color: var(--background-primary);
         .searchBarComponent__22760 {

--- a/src/theme/sidebar/_header.scss
+++ b/src/theme/sidebar/_header.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) #app-mount .sidebar_ded4b5 {
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_ded4b5 {
     .container__7c79d:not(.hasBanner_e78601) .header__104ca {
         background-color: var(--background-primary);
         &:hover {

--- a/src/theme/sidebar/_user-area.scss
+++ b/src/theme/sidebar/_user-area.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-amoled) .sidebar_ded4b5 {
+:is(.theme-dark, .theme-midnight) .sidebar_ded4b5 {
     .panels__58331 {
         .container_ca50b9, .panel_bd8c76, .wrapper__0ed4a > div {
             background-color: var(--background-primary);


### PR DESCRIPTION
- Fixed Nitro page being gray while loading.
  - Changed the variables that are used for black backgrounds. I checked every class that uses `deprecated-store-bg` and `home-background` and there are no conflicts anywhere (removed some code regarding the toolbar and forums due to this change).
- Renamed class `theme-amoled` to `theme-midnight`.

_before/after of the Nitro page:_
![demo](https://github.com/LuckFire/amoled-cord/assets/38290480/cb8ed90e-79ca-4682-b1bb-e2ebd343cb13)
