### PR TITLE
Complete and fix overlay theming, class name adjustments and minor enhancements

### DIFF
--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -92,7 +92,7 @@ html.theme-dark .theme-light .root_f9a4c9,
   --background-secondary: var(--primary-830) !important;
   --background-secondary-alt: var(--primary-800) !important;
   --background-tertiary: var(--primary-860) !important;
-  --bg-mod-faint: hsl(var(--black-hsl)) !important;
+  --bg-mod-faint: var(--black) !important;
   --bg-surface-overlay: var(--primary-830) !important;
   --bg-surface-raised: var(--primary-700) !important;
   --button-outline-primary-background: var(--primary-700) !important;
@@ -259,8 +259,8 @@ html.theme-dark .theme-light .root_f9a4c9,
     ) !important;
     --bg-mod-faint: color-mix(
         in oklab,
-        hsl(var(--black-hsl)) 100%,
-        hsl(var(--theme-base-color-hsl, 0 0% 0%) / 0.08) var(--theme-base-color-amount, 0%)
+        var(--black) 100%,
+        var(--theme-base-color, black) var(--theme-base-color-amount, 0%)
     ) !important;
     --bg-surface-overlay: color-mix(
         in oklab,
@@ -413,11 +413,11 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] {
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchAnswer_b0fa94,
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchFilter_b0fa94 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchAnswer_b0fa94,
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchFilter_b0fa94 {
   background-color: var(--background-primary);
 }
 
@@ -469,7 +469,7 @@ html.theme-dark .theme-light .root_f9a4c9,
 :is(.theme-dark, .theme-midnight) #app-mount .tile_ab47a1 .invalidPoop_ff31dd {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .invite_cdcad9 {
+:is(.theme-dark, .theme-midnight) #app-mount .invite_f61cb8 {
   border-color: var(--background-secondary-alt);
   background-color: var(--background-secondary);
 }
@@ -560,6 +560,10 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--modal-footer-background);
 }
 
+:is(.theme-dark, .theme-midnight) #app-mount .root_f9a4c9 .textArea_a42405 {
+  background-color: var(--input-background);
+}
+
 :is(.theme-dark, .theme-midnight) #app-mount .container_f24a96 {
   background-color: var(--modal-background);
 }
@@ -646,40 +650,66 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .platform-overlay) .overlayActive_e17343 {
-  background-color: hsl(var(--primary-900-hsl)/0.75);
+:is(.theme-dark, .platform-overlay) .overlayActive_e17343, :is(.theme-dark, .platform-overlay) .invalidContainer_e17343 {
+  background-color: hsl(var(--primary-900-hsl)/0.8);
 }
-:is(.theme-dark, .platform-overlay) .layoutUnlocked_e17343 .widget_eb6bd1.default_eb6bd1 {
+:is(.theme-dark, .platform-overlay) .inactiveContainer_e17343 {
   background-color: var(--background-primary);
 }
+:is(.theme-dark, .platform-overlay) .previewingInGameHeader_e17343 {
+  background-color: hsl(var(--primary-900-hsl)/0.9);
+}
 
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .headerContainer_c6d3b6,
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .footer_ac9afa {
+:is(.theme-dark, .platform-overlay) .widget_eb6bd1.default_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .widget_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-tertiary);
+}
+:is(.theme-dark, .platform-overlay) .bar_eb6bd1 {
+  background-color: hsl(var(--primary-900-hsl)/0.85);
+}
+:is(.theme-dark, .platform-overlay) .bar_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .bar_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .body_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .body_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .body_eb6bd1.pinned_eb6bd1 {
+  background-color: hsl(var(--primary-900-hsl)/0.75);
+}
+
+:is(.theme-dark, .platform-overlay) .contained_ac9afa {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63)"] {
   background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa {
-  background-color: var(--background-primary) !important;
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.75)"] {
+  background-color: hsl(var(--black-hsl)/0.75) !important;
+}
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.25)"] {
+  background-color: var(var(--black-hsl)/0.25) !important;
 }
 :is(.theme-dark, .platform-overlay) .opacityHeader_c6d3b6 {
   background-color: var(--background-primary);
-}
-:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .footer_ac9afa,
-:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .headerContainer_c6d3b6 {
-  border-radius: 0px;
 }
 :is(.theme-dark, .platform-overlay) .background-opacity-high .scrollableContainer_d0696b {
   background-color: var(--channeltextarea-background);
 }
 
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933 {
-  background-color: var(--background-primary);
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647 {
+  background-color: hsl(var(--primary-900-hsl)/0.95);
 }
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933:hover {
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647.clickable_f6b647:hover {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933 .dismissButton_b97933 {
-  box-shadow: none;
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .divider_f6b647 {
   background-color: var(--background-secondary-alt);
+}
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .dismissButton_f6b647 {
+  box-shadow: none;
+  background-color: var(--background-secondary);
 }
 
 :is(.theme-dark, .platform-overlay) .option_d2da9c:not(.selected_d2da9c, :hover) {
@@ -689,25 +719,25 @@ html.theme-dark .theme-light .root_f9a4c9,
   color: var(--primary-600);
 }
 
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 {
+:is(.theme-dark, .platform-overlay) .sidebar_d86933,
+:is(.theme-dark, .platform-overlay) .scroller_c47fa9 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .header_d86933,
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .scroller_c47fa9 {
-  background-color: transparent !important;
+:is(.theme-dark, .platform-overlay) .header_d86933,
+:is(.theme-dark, .platform-overlay) .base_aabd07 {
+  background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .searchBar_ec7a6d {
-  box-shadow: none !important;
+:is(.theme-dark, .platform-overlay) .searchBar_ec7a6d {
+  box-shadow: none;
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b > div,
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d > div {
+:is(.theme-dark, .platform-overlay) .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .panels_c0cc4b > div,
+:is(.theme-dark, .platform-overlay) .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .panels_ec7a6d > div {
   background-color: var(--background-primary) !important;
 }
 
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .draggableStartArea_cfed93,
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .body_eb6bd1,
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .controls_c5dd04 {
-  background-color: var(--background-primary);
+:is(.theme-dark, .platform-overlay) .controls_c5dd04,
+:is(.theme-dark, .platform-overlay) .streamerControls_cfed93 {
+  background-color: hsl(var(--primary-900-hsl)/0.85);
 }
 
 :is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_c2739c .separator_cd82a7 {
@@ -910,13 +940,6 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .header_bcd8cb, :is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .autocompleteArrow_bcd8cb {
-  background-color: var(--background-tertiary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .sectionTag_bcd8cb {
-  background-color: var(--background-secondary);
-}
-
 :is(.theme-dark, .theme-midnight) #app-mount .customColorPicker_b91d66 {
   border: none;
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
@@ -1011,7 +1034,10 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 :is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .tierHeaderContent_da77bd {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_c29b00 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .background_a4fd01 {
+  color: var(--background-secondary-alt);
+}
+:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_a6236d {
   background-color: var(--input-background);
 }
 :is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .backgroundContainer_ceff93 {
@@ -1131,6 +1157,9 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 }
 :is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .container_fd6364:not(.hasBanner_fd6364) .header_fd6364:hover {
   background-color: var(--background-secondary);
+}
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .bannerImage_fd6364:before {
+  background: linear-gradient(to bottom, var(--primary-900), transparent 100%);
 }
 :is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .hasBanner_fd6364 [class*=scroller-] {
   background-color: transparent;

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -91,7 +91,7 @@
 	  --background-secondary: var(--primary-830) !important;
 	  --background-secondary-alt: var(--primary-800) !important;
 	  --background-tertiary: var(--primary-860) !important;
-	  --bg-mod-faint: hsl(var(--black-hsl)) !important;
+	  --bg-mod-faint: var(--black) !important;
 	  --bg-surface-overlay: var(--primary-830) !important;
 	  --bg-surface-raised: var(--primary-700) !important;
 	  --button-outline-primary-background: var(--primary-700) !important;
@@ -258,8 +258,8 @@
 	    ) !important;
 	    --bg-mod-faint: color-mix(
 	        in oklab,
-	        hsl(var(--black-hsl)) 100%,
-	        hsl(var(--theme-base-color-hsl, 0 0% 0%) / 0.08) var(--theme-base-color-amount, 0%)
+	        var(--black) 100%,
+	        var(--theme-base-color, black) var(--theme-base-color-amount, 0%)
 	    ) !important;
 	    --bg-surface-overlay: color-mix(
 	        in oklab,
@@ -412,11 +412,11 @@
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchAnswer_b0fa94,
-	:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchFilter_b0fa94 {
+	:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchAnswer_b0fa94,
+	:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchFilter_b0fa94 {
 	  background-color: var(--background-primary);
 	}
 	
@@ -468,7 +468,7 @@
 	:is(.theme-dark, .theme-midnight) #app-mount .tile_ab47a1 .invalidPoop_ff31dd {
 	  background-color: var(--background-secondary-alt);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .invite_cdcad9 {
+	:is(.theme-dark, .theme-midnight) #app-mount .invite_f61cb8 {
 	  border-color: var(--background-secondary-alt);
 	  background-color: var(--background-secondary);
 	}
@@ -559,6 +559,10 @@
 	  background-color: var(--modal-footer-background);
 	}
 	
+	:is(.theme-dark, .theme-midnight) #app-mount .root_f9a4c9 .textArea_a42405 {
+	  background-color: var(--input-background);
+	}
+	
 	:is(.theme-dark, .theme-midnight) #app-mount .container_f24a96 {
 	  background-color: var(--modal-background);
 	}
@@ -645,40 +649,66 @@
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .platform-overlay) .overlayActive_e17343 {
-	  background-color: hsl(var(--primary-900-hsl)/0.75);
+	:is(.theme-dark, .platform-overlay) .overlayActive_e17343, :is(.theme-dark, .platform-overlay) .invalidContainer_e17343 {
+	  background-color: hsl(var(--primary-900-hsl)/0.8);
 	}
-	:is(.theme-dark, .platform-overlay) .layoutUnlocked_e17343 .widget_eb6bd1.default_eb6bd1 {
+	:is(.theme-dark, .platform-overlay) .inactiveContainer_e17343 {
 	  background-color: var(--background-primary);
 	}
+	:is(.theme-dark, .platform-overlay) .previewingInGameHeader_e17343 {
+	  background-color: hsl(var(--primary-900-hsl)/0.9);
+	}
 	
-	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .headerContainer_c6d3b6,
-	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .footer_ac9afa {
+	:is(.theme-dark, .platform-overlay) .widget_eb6bd1.default_eb6bd1 {
+	  background-color: var(--background-primary);
+	}
+	:is(.theme-dark, .platform-overlay) .widget_eb6bd1.unpinned_eb6bd1 {
+	  background-color: var(--background-tertiary);
+	}
+	:is(.theme-dark, .platform-overlay) .bar_eb6bd1 {
+	  background-color: hsl(var(--primary-900-hsl)/0.85);
+	}
+	:is(.theme-dark, .platform-overlay) .bar_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .bar_eb6bd1.unpinned_eb6bd1 {
+	  background-color: var(--background-primary);
+	}
+	:is(.theme-dark, .platform-overlay) .body_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .body_eb6bd1.unpinned_eb6bd1 {
+	  background-color: var(--background-primary);
+	}
+	:is(.theme-dark, .platform-overlay) .body_eb6bd1.pinned_eb6bd1 {
+	  background-color: hsl(var(--primary-900-hsl)/0.75);
+	}
+	
+	:is(.theme-dark, .platform-overlay) .contained_ac9afa {
+	  background-color: var(--background-primary);
+	}
+	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63)"] {
 	  background-color: var(--background-primary) !important;
 	}
-	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa {
-	  background-color: var(--background-primary) !important;
+	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.75)"] {
+	  background-color: hsl(var(--black-hsl)/0.75) !important;
+	}
+	:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.25)"] {
+	  background-color: var(var(--black-hsl)/0.25) !important;
 	}
 	:is(.theme-dark, .platform-overlay) .opacityHeader_c6d3b6 {
 	  background-color: var(--background-primary);
-	}
-	:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .footer_ac9afa,
-	:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .headerContainer_c6d3b6 {
-	  border-radius: 0px;
 	}
 	:is(.theme-dark, .platform-overlay) .background-opacity-high .scrollableContainer_d0696b {
 	  background-color: var(--channeltextarea-background);
 	}
 	
-	:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933 {
-	  background-color: var(--background-primary);
+	:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647 {
+	  background-color: hsl(var(--primary-900-hsl)/0.95);
 	}
-	:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933:hover {
+	:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647.clickable_f6b647:hover {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .platform-overlay) .themePrimary_b97933 .dismissButton_b97933 {
-	  box-shadow: none;
+	:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .divider_f6b647 {
 	  background-color: var(--background-secondary-alt);
+	}
+	:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .dismissButton_f6b647 {
+	  box-shadow: none;
+	  background-color: var(--background-secondary);
 	}
 	
 	:is(.theme-dark, .platform-overlay) .option_d2da9c:not(.selected_d2da9c, :hover) {
@@ -688,25 +718,25 @@
 	  color: var(--primary-600);
 	}
 	
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 {
+	:is(.theme-dark, .platform-overlay) .sidebar_d86933,
+	:is(.theme-dark, .platform-overlay) .scroller_c47fa9 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 .header_d86933,
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 .scroller_c47fa9 {
-	  background-color: transparent !important;
+	:is(.theme-dark, .platform-overlay) .header_d86933,
+	:is(.theme-dark, .platform-overlay) .base_aabd07 {
+	  background-color: var(--background-primary) !important;
 	}
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 .searchBar_ec7a6d {
-	  box-shadow: none !important;
+	:is(.theme-dark, .platform-overlay) .searchBar_ec7a6d {
+	  box-shadow: none;
 	}
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b > div,
-	:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d > div {
+	:is(.theme-dark, .platform-overlay) .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .panels_c0cc4b > div,
+	:is(.theme-dark, .platform-overlay) .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .panels_ec7a6d > div {
 	  background-color: var(--background-primary) !important;
 	}
 	
-	:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .draggableStartArea_cfed93,
-	:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .body_eb6bd1,
-	:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .controls_c5dd04 {
-	  background-color: var(--background-primary);
+	:is(.theme-dark, .platform-overlay) .controls_c5dd04,
+	:is(.theme-dark, .platform-overlay) .streamerControls_cfed93 {
+	  background-color: hsl(var(--primary-900-hsl)/0.85);
 	}
 	
 	:is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_c2739c .separator_cd82a7 {
@@ -909,13 +939,6 @@
 	  background-color: var(--background-primary);
 	}
 	
-	:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .header_bcd8cb, :is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .autocompleteArrow_bcd8cb {
-	  background-color: var(--background-tertiary);
-	}
-	:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .sectionTag_bcd8cb {
-	  background-color: var(--background-secondary);
-	}
-	
 	:is(.theme-dark, .theme-midnight) #app-mount .customColorPicker_b91d66 {
 	  border: none;
 	  box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
@@ -1010,7 +1033,10 @@
 	:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .tierHeaderContent_da77bd {
 	  background-color: var(--background-secondary);
 	}
-	:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_c29b00 {
+	:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .background_a4fd01 {
+	  color: var(--background-secondary-alt);
+	}
+	:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_a6236d {
 	  background-color: var(--input-background);
 	}
 	:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .backgroundContainer_ceff93 {
@@ -1130,6 +1156,9 @@
 	}
 	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .container_fd6364:not(.hasBanner_fd6364) .header_fd6364:hover {
 	  background-color: var(--background-secondary);
+	}
+	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .bannerImage_fd6364:before {
+	  background: linear-gradient(to bottom, var(--primary-900), transparent 100%);
 	}
 	:is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .hasBanner_fd6364 [class*=scroller-] {
 	  background-color: transparent;

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -79,7 +79,7 @@ html.theme-dark .theme-light .root_f9a4c9,
   --background-secondary: var(--primary-830) !important;
   --background-secondary-alt: var(--primary-800) !important;
   --background-tertiary: var(--primary-860) !important;
-  --bg-mod-faint: hsl(var(--black-hsl)) !important;
+  --bg-mod-faint: var(--black) !important;
   --bg-surface-overlay: var(--primary-830) !important;
   --bg-surface-raised: var(--primary-700) !important;
   --button-outline-primary-background: var(--primary-700) !important;
@@ -246,8 +246,8 @@ html.theme-dark .theme-light .root_f9a4c9,
     ) !important;
     --bg-mod-faint: color-mix(
         in oklab,
-        hsl(var(--black-hsl)) 100%,
-        hsl(var(--theme-base-color-hsl, 0 0% 0%) / 0.08) var(--theme-base-color-amount, 0%)
+        var(--black) 100%,
+        var(--theme-base-color, black) var(--theme-base-color-amount, 0%)
     ) !important;
     --bg-surface-overlay: color-mix(
         in oklab,
@@ -400,11 +400,11 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] {
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchAnswer_b0fa94,
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 [class*=searchBar] .searchFilter_b0fa94 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchAnswer_b0fa94,
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 [class*=searchBar] .searchFilter_b0fa94 {
   background-color: var(--background-primary);
 }
 
@@ -456,7 +456,7 @@ html.theme-dark .theme-light .root_f9a4c9,
 :is(.theme-dark, .theme-midnight) #app-mount .tile_ab47a1 .invalidPoop_ff31dd {
   background-color: var(--background-secondary-alt);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .invite_cdcad9 {
+:is(.theme-dark, .theme-midnight) #app-mount .invite_f61cb8 {
   border-color: var(--background-secondary-alt);
   background-color: var(--background-secondary);
 }
@@ -547,6 +547,10 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--modal-footer-background);
 }
 
+:is(.theme-dark, .theme-midnight) #app-mount .root_f9a4c9 .textArea_a42405 {
+  background-color: var(--input-background);
+}
+
 :is(.theme-dark, .theme-midnight) #app-mount .container_f24a96 {
   background-color: var(--modal-background);
 }
@@ -633,40 +637,66 @@ html.theme-dark .theme-light .root_f9a4c9,
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .platform-overlay) .overlayActive_e17343 {
-  background-color: hsl(var(--primary-900-hsl)/0.75);
+:is(.theme-dark, .platform-overlay) .overlayActive_e17343, :is(.theme-dark, .platform-overlay) .invalidContainer_e17343 {
+  background-color: hsl(var(--primary-900-hsl)/0.8);
 }
-:is(.theme-dark, .platform-overlay) .layoutUnlocked_e17343 .widget_eb6bd1.default_eb6bd1 {
+:is(.theme-dark, .platform-overlay) .inactiveContainer_e17343 {
   background-color: var(--background-primary);
 }
+:is(.theme-dark, .platform-overlay) .previewingInGameHeader_e17343 {
+  background-color: hsl(var(--primary-900-hsl)/0.9);
+}
 
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .headerContainer_c6d3b6,
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .footer_ac9afa {
+:is(.theme-dark, .platform-overlay) .widget_eb6bd1.default_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .widget_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-tertiary);
+}
+:is(.theme-dark, .platform-overlay) .bar_eb6bd1 {
+  background-color: hsl(var(--primary-900-hsl)/0.85);
+}
+:is(.theme-dark, .platform-overlay) .bar_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .bar_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .body_eb6bd1.default_eb6bd1, :is(.theme-dark, .platform-overlay) .body_eb6bd1.unpinned_eb6bd1 {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) .body_eb6bd1.pinned_eb6bd1 {
+  background-color: hsl(var(--primary-900-hsl)/0.75);
+}
+
+:is(.theme-dark, .platform-overlay) .contained_ac9afa {
+  background-color: var(--background-primary);
+}
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63)"] {
   background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa {
-  background-color: var(--background-primary) !important;
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.75)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.75)"] {
+  background-color: hsl(var(--black-hsl)/0.75) !important;
+}
+:is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .headerDefault_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .messagesContainer_ac9afa[style*="rgb(54, 57, 63, 0.25)"], :is(.theme-dark, .platform-overlay) :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) .footerContent_ac9afa[style*="rgb(54, 57, 63, 0.25)"] {
+  background-color: var(var(--black-hsl)/0.25) !important;
 }
 :is(.theme-dark, .platform-overlay) .opacityHeader_c6d3b6 {
   background-color: var(--background-primary);
-}
-:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .footer_ac9afa,
-:is(.theme-dark, .platform-overlay) .wrapper_c199cc:has(.default_eb6bd1) .headerContainer_c6d3b6 {
-  border-radius: 0px;
 }
 :is(.theme-dark, .platform-overlay) .background-opacity-high .scrollableContainer_d0696b {
   background-color: var(--channeltextarea-background);
 }
 
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933 {
-  background-color: var(--background-primary);
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647 {
+  background-color: hsl(var(--primary-900-hsl)/0.95);
 }
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933.container_b97933:hover {
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647.container_f6b647.clickable_f6b647:hover {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .platform-overlay) .themePrimary_b97933 .dismissButton_b97933 {
-  box-shadow: none;
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .divider_f6b647 {
   background-color: var(--background-secondary-alt);
+}
+:is(.theme-dark, .platform-overlay) .themePrimary_f6b647 .dismissButton_f6b647 {
+  box-shadow: none;
+  background-color: var(--background-secondary);
 }
 
 :is(.theme-dark, .platform-overlay) .option_d2da9c:not(.selected_d2da9c, :hover) {
@@ -676,25 +706,25 @@ html.theme-dark .theme-light .root_f9a4c9,
   color: var(--primary-600);
 }
 
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 {
+:is(.theme-dark, .platform-overlay) .sidebar_d86933,
+:is(.theme-dark, .platform-overlay) .scroller_c47fa9 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .header_d86933,
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .scroller_c47fa9 {
-  background-color: transparent !important;
+:is(.theme-dark, .platform-overlay) .header_d86933,
+:is(.theme-dark, .platform-overlay) .base_aabd07 {
+  background-color: var(--background-primary) !important;
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .searchBar_ec7a6d {
-  box-shadow: none !important;
+:is(.theme-dark, .platform-overlay) .searchBar_ec7a6d {
+  box-shadow: none;
 }
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_c0cc4b > div,
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .sidebar_d86933 .panels_ec7a6d > div {
+:is(.theme-dark, .platform-overlay) .panels_c0cc4b, :is(.theme-dark, .platform-overlay) .panels_c0cc4b > div,
+:is(.theme-dark, .platform-overlay) .panels_ec7a6d, :is(.theme-dark, .platform-overlay) .panels_ec7a6d > div {
   background-color: var(--background-primary) !important;
 }
 
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .draggableStartArea_cfed93,
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .body_eb6bd1,
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 .controls_c5dd04 {
-  background-color: var(--background-primary);
+:is(.theme-dark, .platform-overlay) .controls_c5dd04,
+:is(.theme-dark, .platform-overlay) .streamerControls_cfed93 {
+  background-color: hsl(var(--primary-900-hsl)/0.85);
 }
 
 :is(.theme-dark, .theme-midnight) #app-mount .nowPlayingColumn_c2739c .separator_cd82a7 {
@@ -897,13 +927,6 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
   background-color: var(--background-primary);
 }
 
-:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .header_bcd8cb, :is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .autocompleteArrow_bcd8cb {
-  background-color: var(--background-tertiary);
-}
-:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb .sectionTag_bcd8cb {
-  background-color: var(--background-secondary);
-}
-
 :is(.theme-dark, .theme-midnight) #app-mount .customColorPicker_b91d66 {
   border: none;
   box-shadow: var(--dark-elevation-border), var(--dark-elevation-high);
@@ -998,7 +1021,10 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 :is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .tierHeaderContent_da77bd {
   background-color: var(--background-secondary);
 }
-:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_c29b00 {
+:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .background_a4fd01 {
+  color: var(--background-secondary-alt);
+}
+:is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .prefixInput_a6236d {
   background-color: var(--input-background);
 }
 :is(.theme-dark, .theme-midnight) #app-mount .layers_d4b6c5 .backgroundContainer_ceff93 {
@@ -1118,6 +1144,9 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 }
 :is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .container_fd6364:not(.hasBanner_fd6364) .header_fd6364:hover {
   background-color: var(--background-secondary);
+}
+:is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .bannerImage_fd6364:before {
+  background: linear-gradient(to bottom, var(--primary-900), transparent 100%);
 }
 :is(.theme-dark, .theme-midnight) #app-mount .sidebar_a4d4d9 .hasBanner_fd6364 [class*=scroller-] {
   background-color: transparent;

--- a/src/core/_variables.scss
+++ b/src/core/_variables.scss
@@ -80,7 +80,7 @@ html.theme-dark .theme-light .root_f9a4c9,
     --background-secondary: var(--primary-830) !important;
     --background-secondary-alt: var(--primary-800) !important;
     --background-tertiary: var(--primary-860) !important;
-    --bg-mod-faint: hsl(var(--black-hsl)) !important;
+    --bg-mod-faint: var(--black) !important;
     --bg-surface-overlay: var(--primary-830) !important;
     --bg-surface-raised: var(--primary-700) !important;
     --button-outline-primary-background: var(--primary-700) !important;
@@ -250,8 +250,8 @@ html.theme-dark .theme-light .root_f9a4c9,
         ) !important;
         --bg-mod-faint: color-mix(
             in oklab,
-            hsl(var(--black-hsl)) 100%,
-            hsl(var(--theme-base-color-hsl, 0 0% 0%) / 0.08) var(--theme-base-color-amount, 0%)
+            var(--black) 100%,
+            var(--theme-base-color, black) var(--theme-base-color-amount, 0%)
         ) !important;
         --bg-surface-overlay: color-mix(
             in oklab,

--- a/src/theme/app/_toolbar.scss
+++ b/src/theme/app/_toolbar.scss
@@ -1,4 +1,4 @@
-:is(.theme-dark, .theme-midnight) #app-mount .container_e44302 {
+:is(.theme-dark, .theme-midnight) #app-mount .container_fc4f04 {
     [class*="searchBar"] {
         background-color: var(--background-secondary);
         .searchAnswer_b0fa94,

--- a/src/theme/chat/_messages.scss
+++ b/src/theme/chat/_messages.scss
@@ -9,8 +9,8 @@
             background-color: var(--background-secondary-alt);
         }
     }
-    // Spotify Invites
-    .invite_cdcad9 {
+    // Activity Invites
+    .invite_f61cb8 {
         border-color: var(--background-secondary-alt);
         background-color: var(--background-secondary);
     }

--- a/src/theme/modals/_activity-invite.scss
+++ b/src/theme/modals/_activity-invite.scss
@@ -1,0 +1,5 @@
+:is(.theme-dark, .theme-midnight) #app-mount .root_f9a4c9 {
+    .textArea_a42405 {
+        background-color: var(--input-background);
+    }
+}

--- a/src/theme/modals/_index.scss
+++ b/src/theme/modals/_index.scss
@@ -1,5 +1,6 @@
 @forward 'accept-invite';
 @forward 'account-switcher';
+@forward 'activity-invite';
 @forward 'create-poll';
 @forward 'delete';
 @forward 'generic';

--- a/src/theme/overlay/_background.scss
+++ b/src/theme/overlay/_background.scss
@@ -1,9 +1,11 @@
-:is(.theme-dark, .platform-overlay)  {
-    .overlayActive_e17343 {
-        background-color: hsl(var(--primary-900-hsl)/.75);
+:is(.theme-dark, .platform-overlay) {
+    .overlayActive_e17343, .invalidContainer_e17343 {
+        background-color: hsl(var(--primary-900-hsl)/0.8);
     }
-
-    .layoutUnlocked_e17343 .widget_eb6bd1.default_eb6bd1 {
+    .inactiveContainer_e17343 {
         background-color: var(--background-primary);
+    }
+    .previewingInGameHeader_e17343 {
+        background-color: hsl(var(--primary-900-hsl)/0.9);
     }
 }

--- a/src/theme/overlay/_base-widget.scss
+++ b/src/theme/overlay/_base-widget.scss
@@ -1,0 +1,25 @@
+:is(.theme-dark, .platform-overlay) {
+    .widget_eb6bd1 {
+        &.default_eb6bd1 {
+            background-color: var(--background-primary);
+        }
+        &.unpinned_eb6bd1 {
+            background-color: var(--background-tertiary);
+        }
+    }
+
+    .bar_eb6bd1 {
+        background-color: hsl(var(--primary-900-hsl)/0.85);
+        &.default_eb6bd1, &.unpinned_eb6bd1 {
+            background-color: var(--background-primary);
+        }
+    }
+    .body_eb6bd1 {
+        &.default_eb6bd1, &.unpinned_eb6bd1 {
+            background-color: var(--background-primary);
+        }
+        &.pinned_eb6bd1 {
+            background-color: hsl(var(--primary-900-hsl)/0.75);
+        }
+    }
+}

--- a/src/theme/overlay/_chat.scss
+++ b/src/theme/overlay/_chat.scss
@@ -1,24 +1,23 @@
 :is(.theme-dark, .platform-overlay) {
-    :is(.contained_ac9afa, .wrapper_c199cc:not(:has(.locked_ac9afa))) {
-        .headerContainer_c6d3b6,
-        .footer_ac9afa {
-            background-color: var(--background-primary) !important;
-        }
-    
-        .messagesContainer_ac9afa {
-            background-color: var(--background-primary) !important;
+    .contained_ac9afa {
+        background-color: var(--background-primary);
+    }
+    :is(.contained_ac9afa, .pinned_ac9afa:not(:has(.locked_ac9afa))) {
+        .headerDefault_ac9afa, .messagesContainer_ac9afa, .footerContent_ac9afa {
+            &[style*='rgb(54, 57, 63)'] {
+                background-color: var(--background-primary) !important;
+            }
+            &[style*='rgb(54, 57, 63, 0.75)'] {
+                background-color: hsl(var(--black-hsl)/0.75) !important;
+            }
+            &[style*='rgb(54, 57, 63, 0.25)'] {
+                background-color: var(var(--black-hsl)/0.25) !important;
+            }
         }
     }
 
     .opacityHeader_c6d3b6 {
         background-color: var(--background-primary);
-    }
-
-    .wrapper_c199cc:has(.default_eb6bd1) {
-        .footer_ac9afa,
-        .headerContainer_c6d3b6 {
-            border-radius: 0px;
-        }
     }
 
     .background-opacity-high .scrollableContainer_d0696b {

--- a/src/theme/overlay/_index.scss
+++ b/src/theme/overlay/_index.scss
@@ -1,6 +1,7 @@
 @forward 'background';
+@forward 'base-widget';
 @forward 'chat';
 @forward 'notice';
 @forward 'settings';
 @forward 'sidebar';
-@forward 'voice-connected';
+@forward 'voice-widget';

--- a/src/theme/overlay/_notice.scss
+++ b/src/theme/overlay/_notice.scss
@@ -1,15 +1,19 @@
 :is(.theme-dark, .platform-overlay) {
-    .themePrimary_b97933 {
-        &.container_b97933 {
-            background-color: var(--background-primary);
-            &:hover {
+    .themePrimary_f6b647 {
+        &.container_f6b647 {
+            background-color: hsl(var(--primary-900-hsl)/0.95);
+            &.clickable_f6b647:hover {
                 background-color: var(--background-secondary);
             }
         }
 
-        .dismissButton_b97933 {
-            box-shadow: none;
+        .divider_f6b647 {
             background-color: var(--background-secondary-alt);
+        }
+
+        .dismissButton_f6b647 {
+            box-shadow: none;
+            background-color: var(--background-secondary);
         }
     }
 }

--- a/src/theme/overlay/_sidebar.scss
+++ b/src/theme/overlay/_sidebar.scss
@@ -1,18 +1,17 @@
-:is(.theme-dark, .platform-overlay) .sidebar_d86933 {
-    background-color: var(--background-primary);
-
-    .header_d86933,
+:is(.theme-dark, .platform-overlay) {
+    .sidebar_d86933,
     .scroller_c47fa9 {
-        background-color: transparent !important;
+        background-color: var(--background-primary);
     }
-
+    .header_d86933,
+    .base_aabd07 {
+        background-color: var(--background-primary) !important;
+    }
     .searchBar_ec7a6d {
-        box-shadow: none !important;
+        box-shadow: none;
     }
-
     .panels_c0cc4b, .panels_c0cc4b > div,
     .panels_ec7a6d, .panels_ec7a6d > div {
         background-color: var(--background-primary) !important;
     }
 }
-

--- a/src/theme/overlay/_voice-connected.scss
+++ b/src/theme/overlay/_voice-connected.scss
@@ -1,7 +1,0 @@
-:is(.theme-dark, .platform-overlay) .widget_eb6bd1.pinned_eb6bd1 {
-    .draggableStartArea_cfed93,
-    .body_eb6bd1,
-    .controls_c5dd04 {
-        background-color: var(--background-primary);
-    }
-}

--- a/src/theme/overlay/_voice-widget.scss
+++ b/src/theme/overlay/_voice-widget.scss
@@ -1,0 +1,6 @@
+:is(.theme-dark, .platform-overlay) {
+    .controls_c5dd04,
+    .streamerControls_cfed93 {
+        background-color: hsl(var(--primary-900-hsl)/0.85);
+    }
+}

--- a/src/theme/popouts/_add-permissions.scss
+++ b/src/theme/popouts/_add-permissions.scss
@@ -1,8 +1,0 @@
-:is(.theme-dark, .theme-midnight) #app-mount .container_bcd8cb {
-    .header_bcd8cb, .autocompleteArrow_bcd8cb {
-        background-color: var(--background-tertiary);
-    }
-    .sectionTag_bcd8cb {
-        background-color: var(--background-secondary);
-    }
-}

--- a/src/theme/popouts/_index.scss
+++ b/src/theme/popouts/_index.scss
@@ -1,5 +1,4 @@
 @forward 'add-game';
-@forward 'add-permissions';
 @forward 'color-picker';
 @forward 'content-warning';
 @forward 'country-code';

--- a/src/theme/settings/_guild.scss
+++ b/src/theme/settings/_guild.scss
@@ -7,6 +7,9 @@
     .tierHeaderContent_da77bd {
         background-color: var(--background-secondary);
     }
+    .background_a4fd01 {
+        color: var(--background-secondary-alt);
+    }
     // Custom Invite Link
     .prefixInput_a6236d {
         background-color: var(--input-background);

--- a/src/theme/settings/_guild.scss
+++ b/src/theme/settings/_guild.scss
@@ -8,17 +8,16 @@
         background-color: var(--background-secondary);
     }
     // Custom Invite Link
-    .prefixInput_c29b00 {
+    .prefixInput_a6236d {
         background-color: var(--input-background);
     }
-    // Rules Screening
+    // Safety Setup
     .backgroundContainer_ceff93 {
         background-color: var(--background-secondary-alt);
     }
     .containerFooter_ceff93 {
         background-color: var(--background-secondary);
     }
-    // Automod
     .iconWrapper_cc6793 {
         background: var(--button-secondary-background);
         .icon_cc6793:hover {

--- a/src/theme/sidebar/_header.scss
+++ b/src/theme/sidebar/_header.scss
@@ -5,6 +5,9 @@
             background-color: var(--background-secondary);
         }
     }
+    .bannerImage_fd6364:before {
+        background: linear-gradient(to bottom, var(--primary-900), transparent 100%);
+    }
     .hasBanner_fd6364 [class*="scroller-"] {
         background-color: transparent;
     }


### PR DESCRIPTION
- [d88afb17aaca2f578e65bffb7340b39c20d95e53] Complete and fix overlay theming: this is still an experiment, but it's good to have it already complete for those who use game overlays. Fixed some class names that have changed, adjusted some parts that need to have a little transparency, opacity support and themed the voice widget when pinned.
- [e5e69c44241db310fe520d41d6ca2d7d979780ea] Fixed some class names that changed: toolbar (search bar), activity invites, custom invite link in server settings.
- [c54628b8f9b94794f8c32d14ebea70398d6b193b] Themed the modal to create activity invites, boost progress (closes #91 ) and a new gradient on the server name.
- [4d7a5253aa27ec260805b8e8a1fe55df14ad5502] Removed the add permissions popout: no longer required, Discord correctly themes this for us.