### PR TITLE
Fix quest bar covering channels sidebar

### DIFF
--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -1172,6 +1172,9 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 > div, :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_adcaac > div {
-  background: var(--background-primary) !important;
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_c721cc,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .panel_bf1a22,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_adcaac,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_b2ca13 {
+  background-color: var(--background-primary);
 }

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -1171,7 +1171,10 @@
 	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 {
 	  background-color: var(--background-primary);
 	}
-	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 > div, :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_adcaac > div {
-	  background: var(--background-primary) !important;
+	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_c721cc,
+	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .panel_bf1a22,
+	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_adcaac,
+	:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_b2ca13 {
+	  background-color: var(--background-primary);
 	}
 }

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -1159,6 +1159,9 @@ body .contentWrapper-3RqEiS .accordionContainer-vSTU_l {
 :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 {
   background-color: var(--background-primary);
 }
-:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 > div, :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_adcaac > div {
-  background: var(--background-primary) !important;
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .wrapper_c721cc,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .panel_bf1a22,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_adcaac,
+:is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 .panels_a4d4d9 .container_b2ca13 {
+  background-color: var(--background-primary);
 }

--- a/src/theme/sidebar/_user-area.scss
+++ b/src/theme/sidebar/_user-area.scss
@@ -1,8 +1,12 @@
 :is(.theme-dark, .theme-midnight) .sidebar_a4d4d9 {
     .panels_a4d4d9 {
         background-color: var(--background-primary);
-        > div, .wrapper_adcaac > div {
-            background: var(--background-primary) !important;
+        // Quest Bar -> Activity Panel -> RTC Connection -> Account
+        .wrapper_c721cc,
+        .panel_bf1a22,
+        .container_adcaac,
+        .container_b2ca13 {
+            background-color: var(--background-primary);
         }
     }
 }


### PR DESCRIPTION
- [d3e9f1510de206cbe8c1aa47eddb8fc84fce9c51] Fixed the quest bar covering the whole channels sidebar (closes: #96 ): I put back the class names instead of selecting each div that is in the panel, to avoid that in the future it happens again that the entire sidebar is covered.