### PR TITLE
[v5.0.3] Minor fixes

### DIFF
--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -132,8 +132,7 @@
 .theme-midnight .channelTextArea_f75fb0 {
   background: var(--background-base-low);
 }
-.theme-midnight .themedBackground__74017,
-.theme-midnight .appLauncherCircleMask_e6e74f {
+.theme-midnight .themedBackground__74017 {
   background: var(--background-base-low);
 }
 .theme-midnight .bannerContainer__362cd {
@@ -369,8 +368,12 @@
   background-color: var(--background-base-lowest);
 }
 
+.theme-midnight .authBox__921c5 {
+  background-color: var(--background-base-lowest);
+}
+
 .theme-midnight .upsellContainer__88422 {
-  background-color: hsl(var(--neutral-35-hsl)/0.1);
+  background-color: var(--opacity-8);
 }
 
 .theme-midnight .accountBtnInner__750de,
@@ -460,8 +463,12 @@
 
 .theme-midnight .container_cbd375,
 .theme-midnight .scroller__23746,
-.theme-midnight .headerBar__8a7fc {
+.theme-midnight .backdrop__8a7fc,
+.theme-midnight .headerBar__8a7fc.relative__8a7fc {
   border-left: 1px solid var(--app-border-frame);
+}
+.theme-midnight .headerBar__8a7fc.overlay__8a7fc {
+  overflow: hidden;
 }
 .theme-midnight .relative__8a7fc {
   border-bottom: 1px solid var(--app-border-frame);
@@ -480,9 +487,18 @@
 .theme-midnight .tabBody__133bf {
   background-color: var(--background-base-lowest);
 }
-.theme-midnight .section__00943 {
-  border-color: var(--border-subtle);
+.theme-midnight .body__00943 .section__00943 {
   background-color: var(--background-base-lowest);
+  border: 1px solid var(--border-subtle);
+}
+.theme-midnight .body__00943 .section__00943:has(+ .separator__00943) {
+  border-bottom: none;
+}
+.theme-midnight .body__00943 .wrapper__960df {
+  border: 1px solid var(--border-subtle);
+}
+.theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
+  border-top: none;
 }
 .theme-midnight .addFriendInputWrapper__72ba7 {
   background: var(--input-background);

--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -2,7 +2,7 @@
  * @name AMOLED-Cord
  * @author LuckFire
  * @description A basically pitch black theme for Discord. Lights out, baby!
- * @version 5.0.2
+ * @version 5.0.3
  * @invite vYdXbEzqDs
  * @authorId 399416615742996480
  * @source https://github.com/LuckFire/amoled-cord

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -131,8 +131,7 @@
 	.theme-midnight .channelTextArea_f75fb0 {
 	  background: var(--background-base-low);
 	}
-	.theme-midnight .themedBackground__74017,
-	.theme-midnight .appLauncherCircleMask_e6e74f {
+	.theme-midnight .themedBackground__74017 {
 	  background: var(--background-base-low);
 	}
 	.theme-midnight .bannerContainer__362cd {
@@ -368,8 +367,12 @@
 	  background-color: var(--background-base-lowest);
 	}
 	
+	.theme-midnight .authBox__921c5 {
+	  background-color: var(--background-base-lowest);
+	}
+	
 	.theme-midnight .upsellContainer__88422 {
-	  background-color: hsl(var(--neutral-35-hsl)/0.1);
+	  background-color: var(--opacity-8);
 	}
 	
 	.theme-midnight .accountBtnInner__750de,
@@ -459,8 +462,12 @@
 	
 	.theme-midnight .container_cbd375,
 	.theme-midnight .scroller__23746,
-	.theme-midnight .headerBar__8a7fc {
+	.theme-midnight .backdrop__8a7fc,
+	.theme-midnight .headerBar__8a7fc.relative__8a7fc {
 	  border-left: 1px solid var(--app-border-frame);
+	}
+	.theme-midnight .headerBar__8a7fc.overlay__8a7fc {
+	  overflow: hidden;
 	}
 	.theme-midnight .relative__8a7fc {
 	  border-bottom: 1px solid var(--app-border-frame);
@@ -479,9 +486,18 @@
 	.theme-midnight .tabBody__133bf {
 	  background-color: var(--background-base-lowest);
 	}
-	.theme-midnight .section__00943 {
-	  border-color: var(--border-subtle);
+	.theme-midnight .body__00943 .section__00943 {
 	  background-color: var(--background-base-lowest);
+	  border: 1px solid var(--border-subtle);
+	}
+	.theme-midnight .body__00943 .section__00943:has(+ .separator__00943) {
+	  border-bottom: none;
+	}
+	.theme-midnight .body__00943 .wrapper__960df {
+	  border: 1px solid var(--border-subtle);
+	}
+	.theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
+	  border-top: none;
 	}
 	.theme-midnight .addFriendInputWrapper__72ba7 {
 	  background: var(--input-background);

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -3,7 +3,7 @@
 	@name AMOLED-Cord
 	@author LuckFire
 	@description A basically pitch black theme for Discord. Lights out, baby!
-	@version 5.0.2
+	@version 5.0.3
 	@namespace https://github.com/discord-extensions/amoled-cord
 	@license MIT
 	==/UserStyle== */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoled-cord",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A basically pitch black theme for Discord. Lights out, baby!",
   "author": "LuckFire",
   "scripts": {

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -119,8 +119,7 @@
 .theme-midnight .channelTextArea_f75fb0 {
   background: var(--background-base-low);
 }
-.theme-midnight .themedBackground__74017,
-.theme-midnight .appLauncherCircleMask_e6e74f {
+.theme-midnight .themedBackground__74017 {
   background: var(--background-base-low);
 }
 .theme-midnight .bannerContainer__362cd {
@@ -356,8 +355,12 @@
   background-color: var(--background-base-lowest);
 }
 
+.theme-midnight .authBox__921c5 {
+  background-color: var(--background-base-lowest);
+}
+
 .theme-midnight .upsellContainer__88422 {
-  background-color: hsl(var(--neutral-35-hsl)/0.1);
+  background-color: var(--opacity-8);
 }
 
 .theme-midnight .accountBtnInner__750de,
@@ -447,8 +450,12 @@
 
 .theme-midnight .container_cbd375,
 .theme-midnight .scroller__23746,
-.theme-midnight .headerBar__8a7fc {
+.theme-midnight .backdrop__8a7fc,
+.theme-midnight .headerBar__8a7fc.relative__8a7fc {
   border-left: 1px solid var(--app-border-frame);
+}
+.theme-midnight .headerBar__8a7fc.overlay__8a7fc {
+  overflow: hidden;
 }
 .theme-midnight .relative__8a7fc {
   border-bottom: 1px solid var(--app-border-frame);
@@ -467,9 +474,18 @@
 .theme-midnight .tabBody__133bf {
   background-color: var(--background-base-lowest);
 }
-.theme-midnight .section__00943 {
-  border-color: var(--border-subtle);
+.theme-midnight .body__00943 .section__00943 {
   background-color: var(--background-base-lowest);
+  border: 1px solid var(--border-subtle);
+}
+.theme-midnight .body__00943 .section__00943:has(+ .separator__00943) {
+  border-bottom: none;
+}
+.theme-midnight .body__00943 .wrapper__960df {
+  border: 1px solid var(--border-subtle);
+}
+.theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
+  border-top: none;
 }
 .theme-midnight .addFriendInputWrapper__72ba7 {
   background: var(--input-background);

--- a/src/theme/content/_chat.scss
+++ b/src/theme/content/_chat.scss
@@ -35,8 +35,7 @@
     .channelTextArea_f75fb0 {
         background: var(--background-base-low);
     }
-    .themedBackground__74017,
-    .appLauncherCircleMask_e6e74f {
+    .themedBackground__74017 {
         background: var(--background-base-low);
     }
     .bannerContainer__362cd {

--- a/src/theme/modals/_auth-box.scss
+++ b/src/theme/modals/_auth-box.scss
@@ -1,0 +1,5 @@
+.theme-midnight {
+    .authBox__921c5 {
+        background-color: var(--background-base-lowest);
+    }
+}

--- a/src/theme/modals/_claim-reward.scss
+++ b/src/theme/modals/_claim-reward.scss
@@ -1,5 +1,5 @@
 .theme-midnight {
     .upsellContainer__88422 {
-        background-color: hsl(var(--neutral-35-hsl) / 0.1);
+        background-color: var(--opacity-8);
     }
 }

--- a/src/theme/modals/_index.scss
+++ b/src/theme/modals/_index.scss
@@ -1,4 +1,5 @@
 @forward 'accept-invite';
+@forward 'auth-box';
 @forward 'claim-reward';
 @forward 'connections';
 @forward 'create-poll';

--- a/src/theme/pages/_discovery.scss
+++ b/src/theme/pages/_discovery.scss
@@ -1,8 +1,13 @@
 .theme-midnight {
     .container_cbd375,
     .scroller__23746,
-    .headerBar__8a7fc {
+    .backdrop__8a7fc,
+    .headerBar__8a7fc.relative__8a7fc {
         border-left: 1px solid var(--app-border-frame);
+    }
+    // Prevent horizontal scrolling caused by the header bar's left border. Also hides the horizontal scrollbar on small screens.
+    .headerBar__8a7fc.overlay__8a7fc {
+        overflow: hidden;
     }
     .relative__8a7fc {
         border-bottom: 1px solid var(--app-border-frame);

--- a/src/theme/pages/_friends.scss
+++ b/src/theme/pages/_friends.scss
@@ -3,9 +3,22 @@
         background-color: var(--background-base-lowest);
     }
 
-    .section__00943 {
-        border-color: var(--border-subtle);
-        background-color: var(--background-base-lowest);
+    .body__00943 {
+        .section__00943 {
+            background-color: var(--background-base-lowest);
+            border: 1px solid var(--border-subtle);
+
+            &:has(+ .separator__00943) {
+                border-bottom: none;
+            }
+        }
+
+        .wrapper__960df {
+            border: 1px solid var(--border-subtle);
+        }
+        .separator__00943 + .wrapper__960df {
+            border-top: none;
+        }
     }
 
     .addFriendInputWrapper__72ba7 {


### PR DESCRIPTION
Bumps to v5.0.3

- [4224f78e2997cf23b140266c3ff9708f5f3a2855] Make "auth boxes" (they are called like this internally) modals black instead of dark gray.
- [26519c73b4daeb07f740830fe093e1697f0f70f3] Add borders to quest ads in friends page "active now". Dynamically add them based on if the separator is present https://discord.com/channels/976700353624039444/1363608297449717823/1370447177653944371.
- [d0d4846773c77fc95148921a2facf0823c9e0e9c] Fix two borders overlapping in discovery page. Also fixes a Discord bug https://discord.com/channels/976700353624039444/1363608297449717823/1385316728623333397 for more info.
- [70591c3c3ae9f5bbba365b3b787fda8dd07f50d0] Remove an unused class name and use an actual variable for the claim reward modal.