### PR TITLE
[v5.0.6] Minor fixes

### DIFF
--- a/clients/amoled-cord.theme.css
+++ b/clients/amoled-cord.theme.css
@@ -2,7 +2,7 @@
  * @name AMOLED-Cord
  * @author LuckFire
  * @description A basically pitch black theme for Discord. Lights out, baby!
- * @version 5.0.5
+ * @version 5.0.6
  * @invite vYdXbEzqDs
  * @authorId 399416615742996480
  * @source https://github.com/LuckFire/amoled-cord
@@ -117,6 +117,16 @@
 }
 .theme-midnight .bannerContainer__362cd {
   background: var(--background-base-low);
+}
+.theme-midnight .formWithLoadedChatInput_f75fb0:before,
+.theme-midnight .chatGradient__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 100%);
+}
+.theme-midnight .chatTypingGradientAtBottom__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 8px, var(--background-base-lowest) 100%);
+}
+.theme-midnight .chatTypingGradientNotAtBottom__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 72px, var(--background-base-lowest) 100%);
 }
 .theme-midnight .optionPill__1464f {
   border: 1px solid var(--border-faint);
@@ -234,9 +244,6 @@
 .theme-midnight .emptySearchWrapper__83bd4 {
   background-color: var(--background-base-lowest);
 }
-.theme-midnight .searchBox_d727b3 {
-  border: 1px solid var(--input-border);
-}
 
 .theme-midnight .videoWrapper__2f4f7:not(.wrapper__48b20),
 .theme-midnight .streamHidden_c30e20,
@@ -299,6 +306,11 @@
   border: 1px solid var(--border-subtle);
 }
 
+.theme-midnight .message__89466 {
+  background-color: var(--background-base-lowest);
+  border: 1px solid var(--border-subtle);
+}
+
 .theme-midnight .uploadModal_dbca3c .footer_dbca3c {
   background-color: var(--background-base-lowest);
 }
@@ -353,6 +365,14 @@
 .theme-midnight .termsFieldBody_fe70ca {
   background-color: var(--background-base-low);
   border: 1px solid var(--border-subtle);
+}
+
+.theme-midnight .premiumBrandRefreshBackground_e5f3a9 {
+  background-color: var(--background-base-lowest) !important;
+}
+.theme-midnight .premiumBrandRefreshHeader_e50a4d,
+.theme-midnight .skuSelectModalContent_e50a4d.premiumBrandRefreshContent_e50a4d.premiumBrandRefreshContent_e50a4d {
+  background-color: var(--background-base-lowest);
 }
 
 .theme-midnight .confirmation__1051d {
@@ -434,11 +454,11 @@
 .theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
   border-top: none;
 }
-.theme-midnight .addFriendInputWrapper__72ba7 {
-  background: var(--input-background);
-}
 .theme-midnight .addFriendInputWrapper__72ba7:not(:focus-within) {
   border-color: var(--input-border);
+}
+.theme-midnight .addFriendInputWrapper__72ba7 {
+  background: var(--input-background);
 }
 .theme-midnight .outer_bf1984 {
   background-color: var(--background-base-low);
@@ -577,7 +597,8 @@
   background-color: var(--background-base-low);
 }
 .theme-midnight .messageContainer__95796,
-.theme-midnight .messages__1ccd1 {
+.theme-midnight .messages__1ccd1,
+.theme-midnight .forumPost__7d15e {
   background-color: var(--background-base-lowest);
 }
 .theme-midnight .tutorial__2692d,
@@ -638,11 +659,14 @@
 .theme-midnight .container_d9c882:not(.browser__9a792) {
   border: 1px solid var(--app-border-frame);
 }
-.theme-midnight .modal__9a792 {
-  background-color: var(--background-base-low) !important;
-}
 .theme-midnight .header_d9c882 {
   background-color: var(--background-base-low);
+}
+.theme-midnight .browser__9a792 {
+  background-color: var(--background-base-lowest);
+}
+.theme-midnight .browser__9a792 .header_d9c882 {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .container__6764b {
   background-color: var(--background-base-lowest);
@@ -661,6 +685,10 @@
 .theme-midnight .contentRegion__23e6b,
 .theme-midnight .contentRegionScroller__23e6b {
   background: var(--background-base-lowest);
+}
+.theme-midnight .content_e9e3ed,
+.theme-midnight .sidebar__409aa {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .accountProfileCard__1fed1 {
   background-color: var(--background-base-low);
@@ -784,27 +812,20 @@
   background-color: var(--background-base-lower);
 }
 .theme-midnight .paymentPane__01014 {
-  border: 1px solid var(--border-faint);
-  background-color: var(--background-base-low);
-}
-.theme-midnight .paymentPane__01014 .paginator__01014 {
   background-color: var(--background-base-low);
 }
 .theme-midnight .paymentPane__01014 .payment_e9cb00 {
   background-color: var(--background-base-low);
 }
-.theme-midnight .paymentPane__01014 .hoverablePayment_e9cb00:hover {
-  background-color: var(--background-surface-high);
-}
-.theme-midnight .paymentPane__01014 .bottomDivider__01014 {
-  border-bottom-color: var(--border-subtle);
-}
 .theme-midnight .paymentPane__01014 .expandedInfo_e9cb00 {
-  border: 1px solid var(--border-subtle);
   background-color: var(--background-base-lowest);
 }
 .theme-midnight .preview__3e443 {
   background-color: var(--background-base-lowest);
+}
+.theme-midnight .container_a1d343 {
+  background-color: var(--background-base-low);
+  border: 1px solid var(--border-subtle);
 }
 .theme-midnight .preview__5d148 {
   background-color: var(--background-base-lowest);
@@ -818,8 +839,15 @@
 .theme-midnight .sliderBar_ac7648:not(.speaking_ac7648) {
   background-color: var(--background-surface-highest);
 }
+.theme-midnight .cameraWrapper_d41d5f {
+  background-color: var(--background-base-low);
+  border-color: var(--border-subtle);
+}
 .theme-midnight .backgroundOptionInner__53965 {
   background-color: var(--background-base-low);
+}
+.theme-midnight .headerContainer__7db08 {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .game_cc46f0 {
   box-shadow: 0 1px 0 0 var(--border-subtle);
@@ -861,9 +889,6 @@
   background-color: var(--background-surface-higher);
 }
 .theme-midnight .actionContainer_bc4513 {
-  background-color: var(--background-surface-highest);
-}
-.theme-midnight .iconWrapper__96f95 {
   background-color: var(--background-surface-highest);
 }
 .theme-midnight .editCard_a25a68 {

--- a/clients/amoled-cord.user.css
+++ b/clients/amoled-cord.user.css
@@ -3,7 +3,7 @@
 	@name AMOLED-Cord
 	@author LuckFire
 	@description A basically pitch black theme for Discord. Lights out, baby!
-	@version 5.0.5
+	@version 5.0.6
 	@namespace https://github.com/discord-extensions/amoled-cord
 	@license MIT
 	==/UserStyle== */
@@ -116,6 +116,16 @@
 	}
 	.theme-midnight .bannerContainer__362cd {
 	  background: var(--background-base-low);
+	}
+	.theme-midnight .formWithLoadedChatInput_f75fb0:before,
+	.theme-midnight .chatGradient__36d07 {
+	  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 100%);
+	}
+	.theme-midnight .chatTypingGradientAtBottom__36d07 {
+	  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 8px, var(--background-base-lowest) 100%);
+	}
+	.theme-midnight .chatTypingGradientNotAtBottom__36d07 {
+	  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 72px, var(--background-base-lowest) 100%);
 	}
 	.theme-midnight .optionPill__1464f {
 	  border: 1px solid var(--border-faint);
@@ -233,9 +243,6 @@
 	.theme-midnight .emptySearchWrapper__83bd4 {
 	  background-color: var(--background-base-lowest);
 	}
-	.theme-midnight .searchBox_d727b3 {
-	  border: 1px solid var(--input-border);
-	}
 	
 	.theme-midnight .videoWrapper__2f4f7:not(.wrapper__48b20),
 	.theme-midnight .streamHidden_c30e20,
@@ -298,6 +305,11 @@
 	  border: 1px solid var(--border-subtle);
 	}
 	
+	.theme-midnight .message__89466 {
+	  background-color: var(--background-base-lowest);
+	  border: 1px solid var(--border-subtle);
+	}
+	
 	.theme-midnight .uploadModal_dbca3c .footer_dbca3c {
 	  background-color: var(--background-base-lowest);
 	}
@@ -352,6 +364,14 @@
 	.theme-midnight .termsFieldBody_fe70ca {
 	  background-color: var(--background-base-low);
 	  border: 1px solid var(--border-subtle);
+	}
+	
+	.theme-midnight .premiumBrandRefreshBackground_e5f3a9 {
+	  background-color: var(--background-base-lowest) !important;
+	}
+	.theme-midnight .premiumBrandRefreshHeader_e50a4d,
+	.theme-midnight .skuSelectModalContent_e50a4d.premiumBrandRefreshContent_e50a4d.premiumBrandRefreshContent_e50a4d {
+	  background-color: var(--background-base-lowest);
 	}
 	
 	.theme-midnight .confirmation__1051d {
@@ -433,11 +453,11 @@
 	.theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
 	  border-top: none;
 	}
-	.theme-midnight .addFriendInputWrapper__72ba7 {
-	  background: var(--input-background);
-	}
 	.theme-midnight .addFriendInputWrapper__72ba7:not(:focus-within) {
 	  border-color: var(--input-border);
+	}
+	.theme-midnight .addFriendInputWrapper__72ba7 {
+	  background: var(--input-background);
 	}
 	.theme-midnight .outer_bf1984 {
 	  background-color: var(--background-base-low);
@@ -576,7 +596,8 @@
 	  background-color: var(--background-base-low);
 	}
 	.theme-midnight .messageContainer__95796,
-	.theme-midnight .messages__1ccd1 {
+	.theme-midnight .messages__1ccd1,
+	.theme-midnight .forumPost__7d15e {
 	  background-color: var(--background-base-lowest);
 	}
 	.theme-midnight .tutorial__2692d,
@@ -637,11 +658,14 @@
 	.theme-midnight .container_d9c882:not(.browser__9a792) {
 	  border: 1px solid var(--app-border-frame);
 	}
-	.theme-midnight .modal__9a792 {
-	  background-color: var(--background-base-low) !important;
-	}
 	.theme-midnight .header_d9c882 {
 	  background-color: var(--background-base-low);
+	}
+	.theme-midnight .browser__9a792 {
+	  background-color: var(--background-base-lowest);
+	}
+	.theme-midnight .browser__9a792 .header_d9c882 {
+	  background-color: var(--background-base-lowest);
 	}
 	.theme-midnight .container__6764b {
 	  background-color: var(--background-base-lowest);
@@ -660,6 +684,10 @@
 	.theme-midnight .contentRegion__23e6b,
 	.theme-midnight .contentRegionScroller__23e6b {
 	  background: var(--background-base-lowest);
+	}
+	.theme-midnight .content_e9e3ed,
+	.theme-midnight .sidebar__409aa {
+	  background-color: var(--background-base-lowest);
 	}
 	.theme-midnight .accountProfileCard__1fed1 {
 	  background-color: var(--background-base-low);
@@ -783,27 +811,20 @@
 	  background-color: var(--background-base-lower);
 	}
 	.theme-midnight .paymentPane__01014 {
-	  border: 1px solid var(--border-faint);
-	  background-color: var(--background-base-low);
-	}
-	.theme-midnight .paymentPane__01014 .paginator__01014 {
 	  background-color: var(--background-base-low);
 	}
 	.theme-midnight .paymentPane__01014 .payment_e9cb00 {
 	  background-color: var(--background-base-low);
 	}
-	.theme-midnight .paymentPane__01014 .hoverablePayment_e9cb00:hover {
-	  background-color: var(--background-surface-high);
-	}
-	.theme-midnight .paymentPane__01014 .bottomDivider__01014 {
-	  border-bottom-color: var(--border-subtle);
-	}
 	.theme-midnight .paymentPane__01014 .expandedInfo_e9cb00 {
-	  border: 1px solid var(--border-subtle);
 	  background-color: var(--background-base-lowest);
 	}
 	.theme-midnight .preview__3e443 {
 	  background-color: var(--background-base-lowest);
+	}
+	.theme-midnight .container_a1d343 {
+	  background-color: var(--background-base-low);
+	  border: 1px solid var(--border-subtle);
 	}
 	.theme-midnight .preview__5d148 {
 	  background-color: var(--background-base-lowest);
@@ -817,8 +838,15 @@
 	.theme-midnight .sliderBar_ac7648:not(.speaking_ac7648) {
 	  background-color: var(--background-surface-highest);
 	}
+	.theme-midnight .cameraWrapper_d41d5f {
+	  background-color: var(--background-base-low);
+	  border-color: var(--border-subtle);
+	}
 	.theme-midnight .backgroundOptionInner__53965 {
 	  background-color: var(--background-base-low);
+	}
+	.theme-midnight .headerContainer__7db08 {
+	  background-color: var(--background-base-lowest);
 	}
 	.theme-midnight .game_cc46f0 {
 	  box-shadow: 0 1px 0 0 var(--border-subtle);
@@ -860,9 +888,6 @@
 	  background-color: var(--background-surface-higher);
 	}
 	.theme-midnight .actionContainer_bc4513 {
-	  background-color: var(--background-surface-highest);
-	}
-	.theme-midnight .iconWrapper__96f95 {
 	  background-color: var(--background-surface-highest);
 	}
 	.theme-midnight .editCard_a25a68 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoled-cord",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "A basically pitch black theme for Discord. Lights out, baby!",
   "author": "LuckFire",
   "scripts": {

--- a/src/amoled-cord.css
+++ b/src/amoled-cord.css
@@ -105,6 +105,16 @@
 .theme-midnight .bannerContainer__362cd {
   background: var(--background-base-low);
 }
+.theme-midnight .formWithLoadedChatInput_f75fb0:before,
+.theme-midnight .chatGradient__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 100%);
+}
+.theme-midnight .chatTypingGradientAtBottom__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 8px, var(--background-base-lowest) 100%);
+}
+.theme-midnight .chatTypingGradientNotAtBottom__36d07 {
+  background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 72px, var(--background-base-lowest) 100%);
+}
 .theme-midnight .optionPill__1464f {
   border: 1px solid var(--border-faint);
   background-color: var(--background-surface-high);
@@ -221,9 +231,6 @@
 .theme-midnight .emptySearchWrapper__83bd4 {
   background-color: var(--background-base-lowest);
 }
-.theme-midnight .searchBox_d727b3 {
-  border: 1px solid var(--input-border);
-}
 
 .theme-midnight .videoWrapper__2f4f7:not(.wrapper__48b20),
 .theme-midnight .streamHidden_c30e20,
@@ -286,6 +293,11 @@
   border: 1px solid var(--border-subtle);
 }
 
+.theme-midnight .message__89466 {
+  background-color: var(--background-base-lowest);
+  border: 1px solid var(--border-subtle);
+}
+
 .theme-midnight .uploadModal_dbca3c .footer_dbca3c {
   background-color: var(--background-base-lowest);
 }
@@ -340,6 +352,14 @@
 .theme-midnight .termsFieldBody_fe70ca {
   background-color: var(--background-base-low);
   border: 1px solid var(--border-subtle);
+}
+
+.theme-midnight .premiumBrandRefreshBackground_e5f3a9 {
+  background-color: var(--background-base-lowest) !important;
+}
+.theme-midnight .premiumBrandRefreshHeader_e50a4d,
+.theme-midnight .skuSelectModalContent_e50a4d.premiumBrandRefreshContent_e50a4d.premiumBrandRefreshContent_e50a4d {
+  background-color: var(--background-base-lowest);
 }
 
 .theme-midnight .confirmation__1051d {
@@ -421,11 +441,11 @@
 .theme-midnight .body__00943 .separator__00943 + .wrapper__960df {
   border-top: none;
 }
-.theme-midnight .addFriendInputWrapper__72ba7 {
-  background: var(--input-background);
-}
 .theme-midnight .addFriendInputWrapper__72ba7:not(:focus-within) {
   border-color: var(--input-border);
+}
+.theme-midnight .addFriendInputWrapper__72ba7 {
+  background: var(--input-background);
 }
 .theme-midnight .outer_bf1984 {
   background-color: var(--background-base-low);
@@ -564,7 +584,8 @@
   background-color: var(--background-base-low);
 }
 .theme-midnight .messageContainer__95796,
-.theme-midnight .messages__1ccd1 {
+.theme-midnight .messages__1ccd1,
+.theme-midnight .forumPost__7d15e {
   background-color: var(--background-base-lowest);
 }
 .theme-midnight .tutorial__2692d,
@@ -625,11 +646,14 @@
 .theme-midnight .container_d9c882:not(.browser__9a792) {
   border: 1px solid var(--app-border-frame);
 }
-.theme-midnight .modal__9a792 {
-  background-color: var(--background-base-low) !important;
-}
 .theme-midnight .header_d9c882 {
   background-color: var(--background-base-low);
+}
+.theme-midnight .browser__9a792 {
+  background-color: var(--background-base-lowest);
+}
+.theme-midnight .browser__9a792 .header_d9c882 {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .container__6764b {
   background-color: var(--background-base-lowest);
@@ -648,6 +672,10 @@
 .theme-midnight .contentRegion__23e6b,
 .theme-midnight .contentRegionScroller__23e6b {
   background: var(--background-base-lowest);
+}
+.theme-midnight .content_e9e3ed,
+.theme-midnight .sidebar__409aa {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .accountProfileCard__1fed1 {
   background-color: var(--background-base-low);
@@ -771,27 +799,20 @@
   background-color: var(--background-base-lower);
 }
 .theme-midnight .paymentPane__01014 {
-  border: 1px solid var(--border-faint);
-  background-color: var(--background-base-low);
-}
-.theme-midnight .paymentPane__01014 .paginator__01014 {
   background-color: var(--background-base-low);
 }
 .theme-midnight .paymentPane__01014 .payment_e9cb00 {
   background-color: var(--background-base-low);
 }
-.theme-midnight .paymentPane__01014 .hoverablePayment_e9cb00:hover {
-  background-color: var(--background-surface-high);
-}
-.theme-midnight .paymentPane__01014 .bottomDivider__01014 {
-  border-bottom-color: var(--border-subtle);
-}
 .theme-midnight .paymentPane__01014 .expandedInfo_e9cb00 {
-  border: 1px solid var(--border-subtle);
   background-color: var(--background-base-lowest);
 }
 .theme-midnight .preview__3e443 {
   background-color: var(--background-base-lowest);
+}
+.theme-midnight .container_a1d343 {
+  background-color: var(--background-base-low);
+  border: 1px solid var(--border-subtle);
 }
 .theme-midnight .preview__5d148 {
   background-color: var(--background-base-lowest);
@@ -805,8 +826,15 @@
 .theme-midnight .sliderBar_ac7648:not(.speaking_ac7648) {
   background-color: var(--background-surface-highest);
 }
+.theme-midnight .cameraWrapper_d41d5f {
+  background-color: var(--background-base-low);
+  border-color: var(--border-subtle);
+}
 .theme-midnight .backgroundOptionInner__53965 {
   background-color: var(--background-base-low);
+}
+.theme-midnight .headerContainer__7db08 {
+  background-color: var(--background-base-lowest);
 }
 .theme-midnight .game_cc46f0 {
   box-shadow: 0 1px 0 0 var(--border-subtle);
@@ -848,9 +876,6 @@
   background-color: var(--background-surface-higher);
 }
 .theme-midnight .actionContainer_bc4513 {
-  background-color: var(--background-surface-highest);
-}
-.theme-midnight .iconWrapper__96f95 {
   background-color: var(--background-surface-highest);
 }
 .theme-midnight .editCard_a25a68 {

--- a/src/theme/content/_chat.scss
+++ b/src/theme/content/_chat.scss
@@ -29,6 +29,27 @@
         background: var(--background-base-low);
     }
 
+    .formWithLoadedChatInput_f75fb0:before,
+    .chatGradient__36d07 {
+        background: linear-gradient(to bottom, transparent, var(--background-base-lowest) 100%);
+    }
+    .chatTypingGradientAtBottom__36d07 {
+        background: linear-gradient(
+            to bottom,
+            transparent,
+            var(--background-base-lowest) 8px,
+            var(--background-base-lowest) 100%
+        );
+    }
+    .chatTypingGradientNotAtBottom__36d07 {
+        background: linear-gradient(
+            to bottom,
+            transparent,
+            var(--background-base-lowest) 72px,
+            var(--background-base-lowest) 100%
+        );
+    }
+
     // Commands
     .optionPill__1464f {
         border: 1px solid var(--border-faint);

--- a/src/theme/modals/_delete-message.scss
+++ b/src/theme/modals/_delete-message.scss
@@ -1,6 +1,6 @@
 .theme-midnight {
-    .pageContainer__09fde,
-    .emptySearchWrapper__83bd4 {
+    .message__89466 {
         background-color: var(--background-base-lowest);
+        border: 1px solid var(--border-subtle);
     }
 }

--- a/src/theme/modals/_index.scss
+++ b/src/theme/modals/_index.scss
@@ -3,6 +3,7 @@
 @forward 'captcha';
 @forward 'claim-reward';
 @forward 'connections';
+@forward 'delete-message';
 @forward 'edit-upload';
 @forward 'gif-picker';
 @forward 'invite';
@@ -11,6 +12,7 @@
 @forward 'mana';
 @forward 'nitro';
 @forward 'onboarding';
+@forward 'payment';
 @forward 'pending-application';
 @forward 'poll-votes';
 @forward 'quest-console-connection';

--- a/src/theme/modals/_payment.scss
+++ b/src/theme/modals/_payment.scss
@@ -1,0 +1,9 @@
+.theme-midnight {
+    .premiumBrandRefreshBackground_e5f3a9 {
+        background-color: var(--background-base-lowest) !important;
+    }
+    .premiumBrandRefreshHeader_e50a4d,
+    .skuSelectModalContent_e50a4d.premiumBrandRefreshContent_e50a4d.premiumBrandRefreshContent_e50a4d {
+        background-color: var(--background-base-lowest);
+    }
+}

--- a/src/theme/popouts/_inbox.scss
+++ b/src/theme/popouts/_inbox.scss
@@ -13,7 +13,8 @@
     }
 
     .messageContainer__95796,
-    .messages__1ccd1 {
+    .messages__1ccd1,
+    .forumPost__7d15e {
         background-color: var(--background-base-lowest);
     }
 

--- a/src/theme/popouts/_threads.scss
+++ b/src/theme/popouts/_threads.scss
@@ -6,12 +6,16 @@
             border: 1px solid var(--app-border-frame);
         }
     }
-    .modal__9a792 {
-        background-color: var(--background-base-low) !important;
-    }
 
     .header_d9c882 {
         background-color: var(--background-base-low);
+    }
+
+    .browser__9a792 {
+        background-color: var(--background-base-lowest);
+        .header_d9c882 {
+            background-color: var(--background-base-lowest);
+        }
     }
 
     .container__6764b {

--- a/src/theme/settings/_content.scss
+++ b/src/theme/settings/_content.scss
@@ -8,6 +8,12 @@
         background: var(--background-base-lowest);
     }
 
+    // V2
+    .content_e9e3ed,
+    .sidebar__409aa {
+        background-color: var(--background-base-lowest);
+    }
+
     // User Settings --> My Account
     .accountProfileCard__1fed1 {
         background-color: var(--background-base-low);
@@ -155,26 +161,13 @@
 
     // User Settings --> Billing
     .paymentPane__01014 {
-        border: 1px solid var(--border-faint);
         background-color: var(--background-base-low);
-
-        .paginator__01014 {
-            background-color: var(--background-base-low);
-        }
 
         .payment_e9cb00 {
             background-color: var(--background-base-low);
         }
-        .hoverablePayment_e9cb00:hover {
-            background-color: var(--background-surface-high);
-        }
-
-        .bottomDivider__01014 {
-            border-bottom-color: var(--border-subtle);
-        }
 
         .expandedInfo_e9cb00 {
-            border: 1px solid var(--border-subtle);
             background-color: var(--background-base-lowest);
         }
     }
@@ -182,6 +175,10 @@
     // User Settings --> Appearance
     .preview__3e443 {
         background-color: var(--background-base-lowest);
+    }
+    .container_a1d343 {
+        background-color: var(--background-base-low);
+        border: 1px solid var(--border-subtle);
     }
 
     // User Settings --> Accessibility
@@ -199,8 +196,17 @@
     .sliderBar_ac7648:not(.speaking_ac7648) {
         background-color: var(--background-surface-highest);
     }
+    .cameraWrapper_d41d5f {
+        background-color: var(--background-base-low);
+        border-color: var(--border-subtle);
+    }
     .backgroundOptionInner__53965 {
         background-color: var(--background-base-low);
+    }
+
+    // User Settings --> Activity Privacy
+    .headerContainer__7db08 {
+        background-color: var(--background-base-lowest);
     }
 
     // User Settings --> Registered Games
@@ -257,9 +263,6 @@
         background-color: var(--background-surface-higher);
     }
     .actionContainer_bc4513 {
-        background-color: var(--background-surface-highest);
-    }
-    .iconWrapper__96f95 {
         background-color: var(--background-surface-highest);
     }
     .editCard_a25a68 {


### PR DESCRIPTION
Bumps to v5.0.6

- Theme black the new gradient added at the bottom of the chat.
- Remove unused styling of the updated search bar in student hubs.
- Theme black the delete message modal.
- Theme black the generic payment/gifting modal.
- Theme black forum posts when in the inbox modal.
- Fix an issue with the threads modal being half black and gray.
- Theme black the upcoming V2 user settings modal.
- Remove unused styling of the billing settings.
- Theme black a small section in activity privacy settings.